### PR TITLE
テキストを英語に統一した

### DIFF
--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -7,7 +7,7 @@ module Api
       file_item = repository.file_items.find(params[:id])
       render json: FileItemSerializer.new(file_item, params: { content: true, full_path: true }), status: :ok
     rescue ActiveRecord::RecordNotFound
-      render json: { error: 'ファイルが存在しません。' }, status: :not_found
+      render json: { error: 'File not found' }, status: :not_found
     end
 
     def update
@@ -20,7 +20,7 @@ module Api
         render json: file_item.errors, status: :unprocessable_entity
       end
     rescue StandardError
-      render json: { error: 'ファイルの更新に失敗しました。' }, status: :internal_server_error
+      render json: { error: 'Failed to update file' }, status: :internal_server_error
     end
 
     private

--- a/backend/app/controllers/api/repositories_controller.rb
+++ b/backend/app/controllers/api/repositories_controller.rb
@@ -11,13 +11,13 @@ module Api
       repository = @current_user.repositories.find(params[:id])
       render json: RepositorySerializer.new(repository, params: { file_items: true }), status: :ok
     rescue ActiveRecord::RecordNotFound
-      render json: { error: 'リポジトリが存在しません。' }, status: :not_found
+      render json: { error: 'Repository not found' }, status: :not_found
     end
 
     def create
       url = repository_params[:url]
       if invalid_url?(url)
-        render json: { error: '無効なURLです。' }, status: :unprocessable_entity
+        render json: { error: 'Invalid URL' }, status: :unprocessable_entity
         return
       end
 
@@ -37,13 +37,13 @@ module Api
           render json: repository.errors, status: :unprocessable_entity
         end
       rescue Octokit::NotFound
-        render json: { error: 'リポジトリが存在しません。' }, status: :not_found
+        render json: { error: 'Repository not found' }, status: :not_found
       rescue Octokit::TooManyRequests
-        render json: { error: 'APIリクエストが多すぎます。少し時間をおいてから再度実行してください。' }, status: :too_many_requests
+        render json: { error: 'Too many requests. Please try again later.' }, status: :too_many_requests
       rescue Octokit::Unauthorized
-        render json: { error: 'アクセストークンが無効です。' }, status: :unauthorized
+        render json: { error: 'Invalid access token' }, status: :unauthorized
       rescue StandardError
-        render json: { error: 'リポジトリ情報の取得中にエラーが発生しました。' }, status: :internal_server_error
+        render json: { error: 'An error occurred. Please try again.' }, status: :internal_server_error
       end
     end
 

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Api::FileItems', type: :request do
 
         expect(response).to have_http_status(:internal_server_error)
         json = response.parsed_body
-        expect(json['error']).to eq('ファイルの更新に失敗しました。')
+        expect(json['error']).to eq('Failed to update file')
       end
     end
   end

--- a/backend/spec/requests/api/repositories_spec.rb
+++ b/backend/spec/requests/api/repositories_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:not_found)
         json = response.parsed_body
-        expect(json['error']).to eq('リポジトリが存在しません。')
+        expect(json['error']).to eq('Repository not found')
       end
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         json = response.parsed_body
-        expect(json['error']).to eq('無効なURLです。')
+        expect(json['error']).to eq('Invalid URL')
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:not_found)
         json = response.parsed_body
-        expect(json['error']).to eq('リポジトリが存在しません。')
+        expect(json['error']).to eq('Repository not found')
       end
     end
 
@@ -182,7 +182,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:too_many_requests)
         json = response.parsed_body
-        expect(json['error']).to eq('APIリクエストが多すぎます。少し時間をおいてから再度実行してください。')
+        expect(json['error']).to eq('Too many requests. Please try again later.')
       end
     end
 
@@ -198,7 +198,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:unauthorized)
         json = response.parsed_body
-        expect(json['error']).to eq('アクセストークンが無効です。')
+        expect(json['error']).to eq('Invalid access token')
       end
     end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Api::Repositories', type: :request do
 
         expect(response).to have_http_status(:internal_server_error)
         json = response.parsed_body
-        expect(json['error']).to eq('リポジトリ情報の取得中にエラーが発生しました。')
+        expect(json['error']).to eq('An error occurred. Please try again.')
       end
     end
   end

--- a/frontend/__tests__/app/repositories/[id]/page.test.tsx
+++ b/frontend/__tests__/app/repositories/[id]/page.test.tsx
@@ -130,7 +130,7 @@ describe('RepositoryDetailPage', () => {
     });
 
     it('renders typing area with explanatory message', async () => {
-      expect(screen.getByText('タイピングするファイルを選んでください。')).toBeInTheDocument();
+      expect(screen.getByText('Select a file to start typing.')).toBeInTheDocument();
     });
   });
 

--- a/frontend/__tests__/app/repositories/new/page.test.tsx
+++ b/frontend/__tests__/app/repositories/new/page.test.tsx
@@ -16,7 +16,7 @@ const inputRepositoryUrlAndSubmit = async (url: string) => {
   } else {
     await userEvent.type(repositoryUrlInput, url);
   }
-  await clickButton('追加');
+  await clickButton('Add Repository');
 };
 
 describe('NewRepositoryPage', () => {
@@ -28,15 +28,15 @@ describe('NewRepositoryPage', () => {
   it('renders title and description', () => {
     render(<NewRepositoryPage />);
 
-    expect(screen.getByText('リポジトリを追加')).toBeInTheDocument();
-    expect(screen.getByText('タイピングしたいGitHubリポジトリのURLを入力してください。')).toBeInTheDocument();
+    expect(screen.getByText('New Repository')).toBeInTheDocument();
+    expect(screen.getByText('Enter the URL of the GitHub repository you want to type.')).toBeInTheDocument();
   });
 
   it('renders form', () => {
     render(<NewRepositoryPage />);
 
     expect(screen.getByPlaceholderText('https://github.com/username/repository')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeInTheDocument();
   });
 
   it('navigates to repository page when submit with valid url', async () => {
@@ -79,7 +79,7 @@ describe('NewRepositoryPage', () => {
 
       await inputRepositoryUrlAndSubmit('invalid-url');
 
-      expect(screen.getByText('有効なURLを入力してください')).toBeInTheDocument();
+      expect(screen.getByText('Enter a valid URL')).toBeInTheDocument();
     });
 
     it('shows error message when submit with empty url', async () => {
@@ -87,7 +87,7 @@ describe('NewRepositoryPage', () => {
 
       await inputRepositoryUrlAndSubmit('');
 
-      expect(screen.getByText('URLは必須です')).toBeInTheDocument();
+      expect(screen.getByText('URL is required')).toBeInTheDocument();
     });
   });
 
@@ -113,7 +113,7 @@ describe('NewRepositoryPage', () => {
 
       await inputRepositoryUrlAndSubmit('https://github.com/username/repository');
 
-      expect(screen.getByText('サーバーエラーが発生しました。')).toBeInTheDocument();
+      expect(screen.getByText('An error occurred. Please try again.')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/__tests__/app/repositories/page.test.tsx
+++ b/frontend/__tests__/app/repositories/page.test.tsx
@@ -101,7 +101,7 @@ describe('RepositoriesPage', () => {
     });
 
     it('renders modal when more-button is clicked', async () => {
-      const moreButtons = screen.getAllByRole('button', { name: 'リポジトリの設定メニュー' });
+      const moreButtons = screen.getAllByRole('button', { name: 'settings' });
       const firstMoreButton = moreButtons[0];
 
       await userEvent.click(firstMoreButton);
@@ -118,9 +118,9 @@ describe('RepositoriesPage', () => {
     });
 
     it('renders empty state', async () => {
-      expect(screen.getByRole('heading', { level: 3, name: 'リポジトリがありません' })).toBeInTheDocument();
-      expect(screen.getByText('リポジトリを追加してタイピングを始めましょう')).toBeInTheDocument();
-      const repositoryAddLinks = screen.getAllByRole('link', { name: 'リポジトリを追加' });
+      expect(screen.getByRole('heading', { level: 3, name: 'No repositories' })).toBeInTheDocument();
+      expect(screen.getByText('Add a repository to start typing.')).toBeInTheDocument();
+      const repositoryAddLinks = screen.getAllByRole('link', { name: 'Add Repository' });
       expect(repositoryAddLinks.length).toBe(2); // リポジトリ0件の表示: 1 + フッター: 1
       expect(repositoryAddLinks[0]).toHaveAttribute('href', '/repositories/new');
     });
@@ -129,7 +129,7 @@ describe('RepositoriesPage', () => {
   it('renders repository-add-button in footer', async () => {
     await renderRepositoriesPage();
 
-    const repositoryAddButton = screen.getByRole('link', { name: 'リポジトリを追加' });
+    const repositoryAddButton = screen.getByRole('link', { name: 'Add Repository' });
 
     expect(repositoryAddButton).toBeInTheDocument();
     expect(repositoryAddButton).toHaveAttribute('href', '/repositories/new');
@@ -149,7 +149,7 @@ describe('RepositoriesPage', () => {
       const repositoriesPage = await RepositoriesPage();
       render(repositoriesPage);
 
-      expect(screen.getByText('エラーが発生しました。再度お試しください。')).toBeInTheDocument();
+      expect(screen.getByText('An error occurred. Please try again.')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/repositories/[id]/page.tsx
+++ b/frontend/src/app/repositories/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function RepositoryDetailPage({ params }: RepositoryDetailP
   try {
     repository = await fetcher(url, accessToken);
   } catch (error: AxiosError | unknown) {
-    const errorMessage = error instanceof AxiosError ? error.message : 'エラーが発生しました。再度お試しください。';
+    const errorMessage = error instanceof AxiosError ? error.message : 'An error occurred. Please try again.';
     return <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>;
   }
 
@@ -34,11 +34,11 @@ export default async function RepositoryDetailPage({ params }: RepositoryDetailP
     <>
       <DropdownMenuItem>
         <Settings className="mr-2 h-4 w-4 font-mono" />
-        設定
+        Settings
       </DropdownMenuItem>
       <DropdownMenuItem className="font-mono text-red-600">
         <Trash2 className="mr-2 h-4 w-4 text-red-600" />
-        リポジトリを削除
+        Delete Repository
       </DropdownMenuItem>
     </>
   );

--- a/frontend/src/app/repositories/new/page.tsx
+++ b/frontend/src/app/repositories/new/page.tsx
@@ -6,7 +6,7 @@ import RepositoryForm from '@/components/repositories/RepositoryForm';
 const NewRepositoryPage: NextPage = () => {
   return (
     <>
-      <Header title="Add Repository" />
+      <Header title="New Repository" />
       <div className="mx-auto max-w-md p-4">
         <p className="mb-4 text-sm text-gray-500">Enter the URL of the GitHub repository you want to type.</p>
         <RepositoryForm />

--- a/frontend/src/app/repositories/new/page.tsx
+++ b/frontend/src/app/repositories/new/page.tsx
@@ -6,9 +6,9 @@ import RepositoryForm from '@/components/repositories/RepositoryForm';
 const NewRepositoryPage: NextPage = () => {
   return (
     <>
-      <Header title="リポジトリを追加" />
+      <Header title="Add Repository" />
       <div className="mx-auto max-w-md p-4">
-        <p className="mb-4 text-sm text-gray-500">タイピングしたいGitHubリポジトリのURLを入力してください。</p>
+        <p className="mb-4 text-sm text-gray-500">Enter the URL of the GitHub repository you want to type.</p>
         <RepositoryForm />
       </div>
     </>

--- a/frontend/src/app/repositories/page.tsx
+++ b/frontend/src/app/repositories/page.tsx
@@ -17,7 +17,7 @@ export default async function RepositoriesPage() {
   try {
     repositories = await fetcher(url, accessToken);
   } catch (error: AxiosError | unknown) {
-    const errorMessage = error instanceof AxiosError ? error.message : 'エラーが発生しました。再度お試しください。';
+    const errorMessage = error instanceof AxiosError ? error.message : 'An error occurred. Please try again.';
     return <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>;
   }
 
@@ -25,7 +25,7 @@ export default async function RepositoriesPage() {
 
   return (
     <>
-      <Header title="リポジトリ一覧" />
+      <Header title="Repositories" />
       <div className="flex min-h-screen flex-col px-2">
         <RepositoryList repositories={sortedRepositories} />
         <RepositoryFooter />

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -19,7 +19,7 @@ export default function Header({ title = '', moreComponent }: HeaderProps) {
           {moreComponent && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" aria-label="リポジトリの設定メニュー">
+                <Button variant="ghost" size="icon" aria-label="settings">
                   <MoreHorizontal className="h-5 w-5" />
                 </Button>
               </DropdownMenuTrigger>

--- a/frontend/src/components/repositories/FileItemView.tsx
+++ b/frontend/src/components/repositories/FileItemView.tsx
@@ -33,11 +33,11 @@ export default function FileItemView({ typingStatus, fileItem, setFileItems, set
     <div className="flex flex-col">
       <Card className="m-4 overflow-hidden">
         {!fileItemData ? (
-          <div className="p-6 text-center font-mono text-gray-500">タイピングするファイルを選んでください。</div>
+          <div className="p-6 text-center font-mono text-gray-500">Select a file to start typing.</div>
         ) : isLoading ? (
-          <div className="p-6 text-center font-mono text-gray-500">ファイルを読み込み中...</div>
+          <div className="p-6 text-center font-mono text-gray-500">Loading file...</div>
         ) : error ? (
-          <div className="p-6 text-center font-mono text-gray-500">エラーが発生しました。再度お試しください。</div>
+          <div className="p-6 text-center font-mono text-gray-500">An error occurred. Please try again.</div>
         ) : (
           <TypingPanel
             fileItem={fileItemData as FileItem}

--- a/frontend/src/components/repositories/RepositoryDetail.tsx
+++ b/frontend/src/components/repositories/RepositoryDetail.tsx
@@ -17,7 +17,9 @@ export default function RepositoryDetail({ initialFileItems }: RepositoryDetailP
 
   const handleFileSelect = (fileItem: FileItem) => {
     if (typingStatus === 'typing' || typingStatus === 'paused') {
-      const confirmSwitch = window.confirm('タイピングを中断して移動しますか？タイピング中のデータは失われます。');
+      const confirmSwitch = window.confirm(
+        'Are you sure you want to switch files? The data you are typing will be lost.',
+      );
       if (!confirmSwitch) {
         return;
       }

--- a/frontend/src/components/repositories/RepositoryForm.tsx
+++ b/frontend/src/components/repositories/RepositoryForm.tsx
@@ -21,9 +21,9 @@ type FormValues = {
 const schema = z.object({
   url: z
     .string()
-    .nonempty('URLは必須です')
-    .url('有効なURLを入力してください')
-    .regex(/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, 'GitHubのリポジトリURLを入力してください'),
+    .nonempty('URL is required')
+    .url('Enter a valid URL')
+    .regex(/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, 'Enter a valid GitHub repository URL'),
 });
 
 export default function RepositoryForm() {
@@ -50,7 +50,7 @@ export default function RepositoryForm() {
       if (axios.isAxiosError(error)) {
         setErrorMessage(error.message);
       } else {
-        setErrorMessage('サーバーエラーが発生しました。');
+        setErrorMessage('An error occurred. Please try again.');
       }
     }
   };
@@ -63,7 +63,7 @@ export default function RepositoryForm() {
           name="url"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>GitHubリポジトリのURL</FormLabel>
+              <FormLabel>GitHub Repository URL</FormLabel>
               <FormControl>
                 <Input placeholder="https://github.com/username/repository" {...field} />
               </FormControl>
@@ -72,7 +72,7 @@ export default function RepositoryForm() {
           )}
         />
         <Button type="submit" disabled={form.formState.isSubmitting}>
-          追加
+          Add Repository
         </Button>
       </form>
     </Form>

--- a/frontend/src/components/repositories/index/RepositoryFooter.tsx
+++ b/frontend/src/components/repositories/index/RepositoryFooter.tsx
@@ -9,7 +9,7 @@ export default function RepositoryFooter() {
       <div className="flex justify-center font-mono">
         <Button variant="outline" asChild>
           <Link href="/repositories/new">
-            <Plus /> リポジトリを追加
+            <Plus /> Add Repository
           </Link>
         </Button>
       </div>

--- a/frontend/src/components/repositories/index/RepositoryList.tsx
+++ b/frontend/src/components/repositories/index/RepositoryList.tsx
@@ -19,12 +19,12 @@ export default function RepositoryList({ repositories }: Props) {
           <div className="mb-4 text-gray-400">
             <FolderOpen className="mx-auto h-12 w-12" />
           </div>
-          <h3 className="mb-2 text-lg font-medium text-gray-900">リポジトリがありません</h3>
-          <p className="mb-6 text-sm text-gray-500">リポジトリを追加してタイピングを始めましょう</p>
+          <h3 className="mb-2 text-lg font-medium text-gray-900">No repositories</h3>
+          <p className="mb-6 text-sm text-gray-500">Add a repository to start typing.</p>
           <Button asChild>
             <Link href="/repositories/new">
               <Plus className="mr-2 h-4 w-4" />
-              リポジトリを追加
+              Add Repository
             </Link>
           </Button>
         </div>

--- a/frontend/src/components/repositories/index/RepositoryListItem.tsx
+++ b/frontend/src/components/repositories/index/RepositoryListItem.tsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow } from 'date-fns';
-import { ja } from 'date-fns/locale';
+import { enUS } from 'date-fns/locale';
 import { MoreHorizontal } from 'lucide-react';
 import Link from 'next/link';
 
@@ -33,11 +33,11 @@ export default function RepositoryListItem({ repository }: Props) {
           <RepositoryProgress progress={repository.progress || 0} />
           {repository.lastTypedAt && (
             <p className="text-muted-foreground font-mono text-sm">
+              typed{' '}
               {formatDistanceToNow(new Date(repository.lastTypedAt), {
                 addSuffix: true,
-                locale: ja,
+                locale: enUS,
               })}
-              にタイプ
             </p>
           )}
         </div>
@@ -45,7 +45,7 @@ export default function RepositoryListItem({ repository }: Props) {
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" aria-label="リポジトリの設定メニュー">
+          <Button variant="ghost" size="icon" aria-label="settings">
             <MoreHorizontal className="h-5 w-5" />
           </Button>
         </DropdownMenuTrigger>


### PR DESCRIPTION
# issue

- #114 

# description
以下の理由で日本語表記を英語表記に変えた。
- ITエンジニア向けのサービスかつ、ITエンジニアに馴染みのある言葉で理解できるため
- リリース時点では日本語のタイピングには対応しないため、サービス内で英語に統一すべきため
- 英語の方がおしゃれ