### PR TITLE
ローディングアイコンを作成した

### DIFF
--- a/frontend/src/components/common/AuthButton.tsx
+++ b/frontend/src/components/common/AuthButton.tsx
@@ -1,6 +1,6 @@
 import { signIn, signOut } from '@/auth';
 import { Button } from '@/components/ui/button';
-import { LogOut } from 'lucide-react';
+import { Github, LogOut } from 'lucide-react';
 
 export function SignIn({ provider }: { provider?: string }) {
   return (
@@ -10,7 +10,8 @@ export function SignIn({ provider }: { provider?: string }) {
         await signIn(provider);
       }}
     >
-      <Button type="submit" variant="outline">
+      <Button type="submit" variant="outline" className="flex items-center gap-2">
+        <Github />
         Sign in with GitHub
       </Button>
     </form>

--- a/frontend/src/components/repositories/RepositoryDetail.tsx
+++ b/frontend/src/components/repositories/RepositoryDetail.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useTypingHandler } from '@/hooks/useTypingHandler';
 import { FileItem, TypingStatus } from '@/types';
 import { Card } from '../ui/card';
+import Loading from '../ui/loading';
 import FileTree from './FileTree';
 import TypingPanel from './TypingPanel';
 
@@ -54,7 +55,7 @@ export default function RepositoryDetail({ initialFileItems }: RepositoryDetailP
         <div className="flex min-w-0 flex-1 flex-col">
           <Card className="mx-4 my-2 flex-1 overflow-hidden">
             {isLoading ? (
-              <div className="p-6 text-center">Loading file...</div>
+              <Loading text="Loading file..." />
             ) : typingHandler.errorMessage ? (
               <div className="p-6 text-center">{typingHandler.errorMessage}</div>
             ) : !selectedFileItem ? (

--- a/frontend/src/components/repositories/RepositoryForm.tsx
+++ b/frontend/src/components/repositories/RepositoryForm.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import axios from 'axios';
+import { LoaderCircle } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -73,7 +74,7 @@ export default function RepositoryForm() {
           )}
         />
         <Button type="submit" variant="outline" disabled={form.formState.isSubmitting}>
-          <Plus />
+          {form.formState.isSubmitting ? <LoaderCircle className="animate-spin" /> : <Plus />}
           Add Repository
         </Button>
       </form>

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -2,7 +2,6 @@ import { LoaderCircle } from 'lucide-react';
 
 type LoadingProps = {
   text?: string;
-  className?: string;
 };
 
 export default function Loading({ text = 'Loading...' }: LoadingProps) {

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -1,0 +1,15 @@
+import { LoaderCircle } from 'lucide-react';
+
+type LoadingProps = {
+  text?: string;
+  className?: string;
+};
+
+export default function Loading({ text = 'Loading...' }: LoadingProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
+      <LoaderCircle className="animate-spin" />
+      <span>{text}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
# issue
- #144 

# description
- ローディングアイコンを表示するようにした
- サインインボタンにgithubアイコンをつけた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 汎用的なローディング表示コンポーネントを追加しました。
  * リポジトリフォームの送信ボタンにローディングスピナーを表示するようになりました。

* **改善**
  * 「Sign in with GitHub」ボタンにGitHubアイコンを追加し、見た目を改善しました。
  * リポジトリ詳細画面のローディング表示が新しいローディングコンポーネントに変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->