### PR TITLE
タイピング中の統計情報を表示するようにした

### DIFF
--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -42,7 +42,7 @@ module Api
 
     def file_item_params
       params.expect(file_item: [:status, {
-                      typing_progress: [:row, :column, :time, :total_typo_count, {
+                      typing_progress: [:row, :column, :elapsed_seconds, :total_correct_type_count, :total_typo_count, {
                         typos_attributes: [%i[row column character _destroy]]
                       }]
                     }])

--- a/backend/app/models/typing_progress.rb
+++ b/backend/app/models/typing_progress.rb
@@ -8,6 +8,7 @@ class TypingProgress < ApplicationRecord
 
   validates :row, presence: true
   validates :column, presence: true
-  validates :time, presence: true
-  validates :total_typo_count, presence: true
+  validates :elapsed_seconds, presence: true
+  validates :total_correct_type_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :total_typo_count, presence: true, numericality: { greater_than_or_equal_to: 0}
 end

--- a/backend/app/models/typing_progress.rb
+++ b/backend/app/models/typing_progress.rb
@@ -6,9 +6,9 @@ class TypingProgress < ApplicationRecord
 
   accepts_nested_attributes_for :typos, allow_destroy: true
 
-  validates :row, presence: true
-  validates :column, presence: true
-  validates :elapsed_seconds, presence: true
-  validates :total_correct_type_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :total_typo_count, presence: true, numericality: { greater_than_or_equal_to: 0}
+  validates :row, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :column, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :elapsed_seconds, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :total_correct_type_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :total_typo_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/backend/app/serializers/typing_progress_serializer.rb
+++ b/backend/app/serializers/typing_progress_serializer.rb
@@ -6,21 +6,21 @@ class TypingProgressSerializer
   attributes :row, :column, :elapsed_seconds, :total_correct_type_count, :total_typo_count
 
   attribute :accuracy do |typing_progress|
-    total_chars = typing_progress.total_correct_type_count + typing_progress.total_typo_count
-    if total_chars.zero?
+    total_type_count = typing_progress.total_correct_type_count + typing_progress.total_typo_count
+    if total_type_count.zero?
       100.0
     else
-      ((typing_progress.total_correct_type_count.to_f / total_chars) * 100).round(1)
+      (typing_progress.total_correct_type_count.fdiv(total_type_count) * 100).round(1)
     end
   end
 
   attribute :wpm do |typing_progress|
-    elapsed_minutes = typing_progress.elapsed_seconds / 60.0
+    elapsed_minutes = typing_progress.elapsed_seconds.fdiv(60)
     if elapsed_minutes.zero?
       0.0
     else
-      typed_words = typing_progress.total_correct_type_count / 5
-      (typed_words / elapsed_minutes).round(1)
+      typed_words = typing_progress.total_correct_type_count.fdiv(5)
+      typed_words.fdiv(elapsed_minutes).round(1)
     end
   end
 

--- a/backend/app/serializers/typing_progress_serializer.rb
+++ b/backend/app/serializers/typing_progress_serializer.rb
@@ -3,7 +3,25 @@
 class TypingProgressSerializer
   include Alba::Serializer
 
-  attributes :row, :column, :time, :total_typo_count
+  attributes :row, :column, :elapsed_seconds, :total_correct_type_count, :total_typo_count
+
+  attribute :accuracy do |typing_progress|
+    total_chars = typing_progress.total_correct_type_count + typing_progress.total_typo_count
+    if total_chars.positive?
+      ((typing_progress.total_correct_type_count.to_f / total_chars) * 100).round
+    else
+      100
+    end
+  end
+
+  attribute :wpm do |typing_progress|
+    elapsed_minutes = typing_progress.elapsed_seconds / 60.0
+    if elapsed_minutes.positive? && typing_progress.total_correct_type_count.positive?
+      (typing_progress.total_correct_type_count / 5.0 / elapsed_minutes).round
+    else
+      0
+    end
+  end
 
   attribute :typos do |typing_progress|
     typing_progress.typos.map do |typo|

--- a/backend/app/serializers/typing_progress_serializer.rb
+++ b/backend/app/serializers/typing_progress_serializer.rb
@@ -7,19 +7,20 @@ class TypingProgressSerializer
 
   attribute :accuracy do |typing_progress|
     total_chars = typing_progress.total_correct_type_count + typing_progress.total_typo_count
-    if total_chars.positive?
-      ((typing_progress.total_correct_type_count.to_f / total_chars) * 100).round
+    if total_chars.zero?
+      100.0
     else
-      100
+      ((typing_progress.total_correct_type_count.to_f / total_chars) * 100).round(1)
     end
   end
 
   attribute :wpm do |typing_progress|
     elapsed_minutes = typing_progress.elapsed_seconds / 60.0
-    if elapsed_minutes.positive? && typing_progress.total_correct_type_count.positive?
-      (typing_progress.total_correct_type_count / 5.0 / elapsed_minutes).round
+    if elapsed_minutes.zero?
+      0.0
     else
-      0
+      typed_words = typing_progress.total_correct_type_count / 5
+      (typed_words / elapsed_minutes).round(1)
     end
   end
 

--- a/backend/db/migrate/20250820075935_setup_typing_progresses_with_stats.rb
+++ b/backend/db/migrate/20250820075935_setup_typing_progresses_with_stats.rb
@@ -1,0 +1,15 @@
+class SetupTypingProgressesWithStats < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :typing_progresses, :time, :elapsed_seconds
+    change_column :typing_progresses, :elapsed_seconds, :integer, null: false, default: 0
+
+    add_column :typing_progresses, :total_correct_type_count, :integer, null: false, default: 0
+  end
+
+  def down
+    remove_column :typing_progresses, :total_correct_type_count
+
+    change_column :typing_progresses, :elapsed_seconds, :decimal, precision: 8, scale: 1, null: false, default: 0.0
+    rename_column :typing_progresses, :elapsed_seconds, :time
+  end
+end

--- a/backend/db/migrate/20250820075935_setup_typing_progresses_with_stats.rb
+++ b/backend/db/migrate/20250820075935_setup_typing_progresses_with_stats.rb
@@ -1,15 +1,14 @@
 class SetupTypingProgressesWithStats < ActiveRecord::Migration[8.0]
-  def up
+  def change
     rename_column :typing_progresses, :time, :elapsed_seconds
     change_column :typing_progresses, :elapsed_seconds, :integer, null: false, default: 0
 
     add_column :typing_progresses, :total_correct_type_count, :integer, null: false, default: 0
-  end
 
-  def down
-    remove_column :typing_progresses, :total_correct_type_count
-
-    change_column :typing_progresses, :elapsed_seconds, :decimal, precision: 8, scale: 1, null: false, default: 0.0
-    rename_column :typing_progresses, :elapsed_seconds, :time
+    add_check_constraint :typing_progresses, "elapsed_seconds >= 0", name: "typing_progresses_elapsed_seconds_nonneg"
+    add_check_constraint :typing_progresses, "total_typo_count >= 0", name: "typing_progresses_total_typo_count_nonneg"
+    add_check_constraint :typing_progresses, "total_correct_type_count >= 0", name: "typing_progresses_total_correct_type_count_nonneg"
+    add_check_constraint :typing_progresses, "row >= 0", name: "typing_progresses_row_nonneg"
+    add_check_constraint :typing_progresses, "\"column\" >= 0", name: "typing_progresses_column_nonneg"
   end
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_03_133913) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_075935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -58,12 +58,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_03_133913) do
 
   create_table "typing_progresses", force: :cascade do |t|
     t.bigint "file_item_id", null: false
-    t.decimal "time", precision: 8, scale: 1, null: false
+    t.integer "elapsed_seconds", default: 0, null: false
     t.integer "row", null: false
     t.integer "column", null: false
     t.integer "total_typo_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "total_correct_type_count", default: 0, null: false
     t.index ["file_item_id"], name: "index_typing_progresses_on_file_item_id"
   end
 

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -66,6 +66,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_075935) do
     t.datetime "updated_at", null: false
     t.integer "total_correct_type_count", default: 0, null: false
     t.index ["file_item_id"], name: "index_typing_progresses_on_file_item_id"
+    t.check_constraint "\"column\" >= 0", name: "typing_progresses_column_nonneg"
+    t.check_constraint "\"row\" >= 0", name: "typing_progresses_row_nonneg"
+    t.check_constraint "elapsed_seconds >= 0", name: "typing_progresses_elapsed_seconds_nonneg"
+    t.check_constraint "total_correct_type_count >= 0", name: "typing_progresses_total_correct_type_count_nonneg"
+    t.check_constraint "total_typo_count >= 0", name: "typing_progresses_total_typo_count_nonneg"
   end
 
   create_table "typos", force: :cascade do |t|

--- a/backend/spec/factories/file_items.rb
+++ b/backend/spec/factories/file_items.rb
@@ -28,12 +28,7 @@ FactoryBot.define do
 
     trait :with_typing_progress do
       after(:create) do |file_item|
-        create(:typing_progress,
-               row: 0,
-               column: 0,
-               elapsed_seconds: 0,
-               total_typo_count: 0,
-               file_item:)
+        create(:typing_progress, file_item:)
       end
     end
   end

--- a/backend/spec/factories/file_items.rb
+++ b/backend/spec/factories/file_items.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
         create(:typing_progress,
                row: 0,
                column: 0,
-               time: 0,
+               elapsed_seconds: 0,
                total_typo_count: 0,
                file_item:)
       end

--- a/backend/spec/factories/typing_progress.rb
+++ b/backend/spec/factories/typing_progress.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     row { 0 }
     column { 0 }
     elapsed_seconds { 0 }
+    total_correct_type_count { 0 }
     total_typo_count { 0 }
   end
 end

--- a/backend/spec/factories/typing_progress.rb
+++ b/backend/spec/factories/typing_progress.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     file_item
     row { 0 }
     column { 0 }
-    time { 0 }
+    elapsed_seconds { 0 }
     total_typo_count { 0 }
   end
 end

--- a/backend/spec/models/file_item_spec.rb
+++ b/backend/spec/models/file_item_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe FileItem, type: :model do
   def expect_typing_progress_attributes(typing_progress, file_item)
     expect(typing_progress.row).to eq(file_item.content.lines.count)
     expect(typing_progress.column).to eq(file_item.content.lines.first.length)
-    expect(typing_progress.elapsed_seconds).to eq(0)
-    expect(typing_progress.total_typo_count).to eq(0)
+    expect(typing_progress.elapsed_seconds).to be_zero
+    expect(typing_progress.total_typo_count).to be_zero
   end
 
   def expect_typo_attributes(typos)
@@ -72,11 +72,11 @@ RSpec.describe FileItem, type: :model do
   end
 
   def expect_initial_typing_progress_attributes(typing_progress)
-    expect(typing_progress.row).to eq(0)
-    expect(typing_progress.column).to eq(0)
-    expect(typing_progress.elapsed_seconds).to eq(0)
-    expect(typing_progress.total_typo_count).to eq(0)
-    expect(typing_progress.typos.count).to eq(0)
+    expect(typing_progress.row).to be_zero
+    expect(typing_progress.column).to be_zero
+    expect(typing_progress.elapsed_seconds).to be_zero
+    expect(typing_progress.total_typo_count).to be_zero
+    expect(typing_progress.typos.count).to be_zero
   end
 
   def expect_validation_errors(file_item)

--- a/backend/spec/models/file_item_spec.rb
+++ b/backend/spec/models/file_item_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FileItem, type: :model do
     {
       row: untyped_file_item.content.lines.count,
       column: untyped_file_item.content.lines.first.length,
-      time: 0,
+      elapsed_seconds: 0,
       total_typo_count: 0,
       typos_attributes: [
         {
@@ -40,7 +40,7 @@ RSpec.describe FileItem, type: :model do
       typing_progress: {
         row: nil,
         column: nil,
-        time: nil,
+        elapsed_seconds: nil,
         total_typo_count: nil
       }
     }
@@ -49,7 +49,7 @@ RSpec.describe FileItem, type: :model do
   def expect_typing_progress_attributes(typing_progress, file_item)
     expect(typing_progress.row).to eq(file_item.content.lines.count)
     expect(typing_progress.column).to eq(file_item.content.lines.first.length)
-    expect(typing_progress.time).to eq(0)
+    expect(typing_progress.elapsed_seconds).to eq(0)
     expect(typing_progress.total_typo_count).to eq(0)
   end
 
@@ -74,7 +74,7 @@ RSpec.describe FileItem, type: :model do
   def expect_initial_typing_progress_attributes(typing_progress)
     expect(typing_progress.row).to eq(0)
     expect(typing_progress.column).to eq(0)
-    expect(typing_progress.time).to eq(0)
+    expect(typing_progress.elapsed_seconds).to eq(0)
     expect(typing_progress.total_typo_count).to eq(0)
     expect(typing_progress.typos.count).to eq(0)
   end
@@ -83,7 +83,7 @@ RSpec.describe FileItem, type: :model do
     errors = file_item.errors
     expect(errors[:'typing_progress.row']).to include("can't be blank")
     expect(errors[:'typing_progress.column']).to include("can't be blank")
-    expect(errors[:'typing_progress.time']).to include("can't be blank")
+    expect(errors[:'typing_progress.elapsed_seconds']).to include("can't be blank")
     expect(errors[:'typing_progress.total_typo_count']).to include("can't be blank")
   end
 

--- a/backend/spec/models/repository_spec.rb
+++ b/backend/spec/models/repository_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Repository, type: :model do
     end
 
     it 'saves file_items with tree structure' do
-      expect(repository.file_items.count).to eq(0)
+      expect(repository.file_items.count).to be_zero
       repository.send(:save_file_items, github_client_mock)
 
       expect(repository.file_items.count).to eq(6)
@@ -260,7 +260,7 @@ RSpec.describe Repository, type: :model do
       end
 
       it 'creates file_items with tree structure' do
-        expect(repository.file_items.count).to eq(0)
+        expect(repository.file_items.count).to be_zero
         repository.send(:create_file_items_recursively, file_tree)
 
         expect(repository.file_items.count).to eq(5)
@@ -296,10 +296,10 @@ RSpec.describe Repository, type: :model do
       end
 
       it 'does not create file_items' do
-        expect(repository.file_items.count).to eq(0)
+        expect(repository.file_items.count).to be_zero
         repository.send(:create_file_items_recursively, file_tree)
 
-        expect(repository.file_items.count).to eq(0)
+        expect(repository.file_items.count).to be_zero
       end
 
       it 'adds errors to the repository' do
@@ -407,7 +407,7 @@ RSpec.describe Repository, type: :model do
     let(:repository) { build(:repository) }
 
     it 'calculates path depth correctly' do
-      expect(repository.send(:depth_of, 'file.rb')).to eq(0)
+      expect(repository.send(:depth_of, 'file.rb')).to be_zero
       expect(repository.send(:depth_of, 'src/main.rb')).to eq(1)
       expect(repository.send(:depth_of, 'src/lib/helper.rb')).to eq(2)
     end

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -6,16 +6,29 @@ RSpec.describe 'Api::FileItems', type: :request do
   include_context 'with authenticated user'
 
   let!(:repository) { create(:repository, :with_file_items, user: user) }
-  let(:file_item) { repository.file_items.where(type: :file).first }
-  let(:nil_content_file_item) { create(:file_item, :nil_content, repository:) }
 
   describe 'GET /api/repositories/:repository_id/file_items/:id' do
-    context 'when content exists' do
-      it 'returns the file item and success status' do
-        get api_repository_file_item_path(repository_id: repository.id, id: file_item.id), headers: headers
+    let(:file_item) { create(:file_item, :typing, repository:) }
+    let(:nil_content_file_item) { create(:file_item, :nil_content, repository:) }
 
+    context 'when content exists' do
+      let(:typing_progress) do
+        create(:typing_progress, file_item:, row: 5, column: 5, elapsed_seconds: 60, total_correct_type_count: 150,
+                                 total_typo_count: 10)
+      end
+
+      before do
+        create(:typo, typing_progress:, row: 1, column: 1, character: 'a')
+        get api_repository_file_item_path(repository_id: repository.id, id: file_item.id), headers: headers
+      end
+
+      it 'returns the success status' do
         expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the file item' do
         json = response.parsed_body
+
         expect(json).to have_json_attributes(
           id: file_item.id,
           name: file_item.name,
@@ -25,16 +38,57 @@ RSpec.describe 'Api::FileItems', type: :request do
           content: file_item.content
         )
       end
+
+      it 'returns the typing progress' do
+        json = response.parsed_body
+
+        expect(json['typing_progress']).to have_json_attributes(
+          row: 5,
+          column: 5,
+          elapsed_seconds: 60,
+          total_correct_type_count: 150,
+          total_typo_count: 10,
+          accuracy: 93.8,
+          wpm: 30.0
+        )
+
+        expect(json['typing_progress']['typos'].first).to include(
+          row: 1,
+          column: 1,
+          character: 'a'
+        )
+      end
+    end
+
+    context 'when typing progress has zero values' do
+      it 'returns accuracy as 100.0 and wpm as 0.0' do
+        create(:typing_progress, file_item:, row: 0, column: 0, elapsed_seconds: 0, total_correct_type_count: 0,
+                                 total_typo_count: 0)
+        get api_repository_file_item_path(repository_id: repository.id, id: file_item.id), headers: headers
+
+        json = response.parsed_body
+
+        expect(json['typing_progress']).to have_json_attributes(
+          row: 0,
+          column: 0,
+          elapsed_seconds: 0,
+          total_correct_type_count: 0,
+          total_typo_count: 0,
+          accuracy: 100.0,
+          wpm: 0.0
+        )
+      end
     end
 
     context 'when content is nil' do
       before do
         github_client_mock = instance_double(Octokit::Client)
         allow(Octokit::Client).to receive(:new).and_return(github_client_mock)
+        content = '44GT44KT44Gr44Gh44Gv44CB5LiW55WM77yB' # こんにちは、世界！
         allow(github_client_mock)
           .to receive(:contents)
           .with(repository.url, path: nil_content_file_item.path, ref: repository.commit_hash)
-          .and_return({ content: '44GT44KT44Gr44Gh44Gv44CB5LiW55WM77yB' })
+          .and_return({ content: })
       end
 
       it 'updates the file item content' do
@@ -125,6 +179,8 @@ RSpec.describe 'Api::FileItems', type: :request do
                     row: untyped_file_item.content.split("\n").size - 1,
                     column: untyped_file_item.content.split("\n").last.size,
                     elapsed_seconds: 330,
+                    total_correct_type_count: 50,
+                    total_typo_count: 10,
                     typos_attributes: [
                       { row: 1, column: 1, character: 'a' },
                       { row: 2, column: 2, character: 'b' }
@@ -155,6 +211,8 @@ RSpec.describe 'Api::FileItems', type: :request do
         expect(updated_file_item.typing_progress.row).to eq(untyped_file_item.content.split("\n").size - 1)
         expect(updated_file_item.typing_progress.column).to eq(untyped_file_item.content.split("\n").last.size)
         expect(updated_file_item.typing_progress.elapsed_seconds).to eq(330)
+        expect(updated_file_item.typing_progress.total_correct_type_count).to eq(50)
+        expect(updated_file_item.typing_progress.total_typo_count).to eq(10)
 
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
         expect(updated_file_item.typing_progress.typos[0].row).to eq(1)
@@ -176,6 +234,8 @@ RSpec.describe 'Api::FileItems', type: :request do
                     row: 3,
                     column: 1,
                     elapsed_seconds: 330,
+                    total_correct_type_count: 50,
+                    total_typo_count: 10,
                     typos_attributes: [
                       { row: 1, column: 1, character: 'a' },
                       { row: 2, column: 2, character: 'b' }
@@ -204,6 +264,8 @@ RSpec.describe 'Api::FileItems', type: :request do
         expect(updated_file_item.typing_progress.row).to eq(3)
         expect(updated_file_item.typing_progress.column).to eq(1)
         expect(updated_file_item.typing_progress.elapsed_seconds).to eq(330)
+        expect(updated_file_item.typing_progress.total_correct_type_count).to eq(50)
+        expect(updated_file_item.typing_progress.total_typo_count).to eq(10)
 
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
         expect(updated_file_item.typing_progress.typos[0].row).to eq(1)
@@ -217,7 +279,7 @@ RSpec.describe 'Api::FileItems', type: :request do
 
     context 'when repository does not exist' do
       it 'returns not found status' do
-        patch api_repository_file_item_path(repository_id: 0, id: file_item.id),
+        patch api_repository_file_item_path(repository_id: 0, id: untyped_file_item.id),
               params: { file_item: { status: :typed } }, headers: headers
 
         expect(response).to have_http_status(:not_found)
@@ -251,7 +313,7 @@ RSpec.describe 'Api::FileItems', type: :request do
 
     context 'when invalid status is given' do
       it 'returns bad request status' do
-        patch api_repository_file_item_path(repository_id: repository.id, id: file_item.id),
+        patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
               params: { file_item: { status: :invalid } }, headers: headers
 
         expect(response).to have_http_status(:bad_request)

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe 'Api::FileItems', type: :request do
         expect(updated_file_item.typing_progress.row).to eq(3)
         expect(updated_file_item.typing_progress.column).to eq(1)
         expect(updated_file_item.typing_progress.elapsed_seconds).to eq(330)
-        expect(updated_file_item.typing_progress.typos.length).to eq(2)
 
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
         expect(updated_file_item.typing_progress.typos[0].row).to eq(1)

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Api::FileItems', type: :request do
                   typing_progress: {
                     row: untyped_file_item.content.split("\n").size - 1,
                     column: untyped_file_item.content.split("\n").last.size,
-                    time: 330.5,
+                    elapsed_seconds: 330,
                     typos_attributes: [
                       { row: 1, column: 1, character: 'a' },
                       { row: 2, column: 2, character: 'b' }
@@ -154,7 +154,7 @@ RSpec.describe 'Api::FileItems', type: :request do
         updated_file_item = FileItem.find(untyped_file_item.id)
         expect(updated_file_item.typing_progress.row).to eq(untyped_file_item.content.split("\n").size - 1)
         expect(updated_file_item.typing_progress.column).to eq(untyped_file_item.content.split("\n").last.size)
-        expect(updated_file_item.typing_progress.time).to eq(330.5)
+        expect(updated_file_item.typing_progress.elapsed_seconds).to eq(330)
 
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
         expect(updated_file_item.typing_progress.typos[0].row).to eq(1)
@@ -175,7 +175,7 @@ RSpec.describe 'Api::FileItems', type: :request do
                   typing_progress: {
                     row: 3,
                     column: 1,
-                    time: 330.5,
+                    elapsed_seconds: 330,
                     typos_attributes: [
                       { row: 1, column: 1, character: 'a' },
                       { row: 2, column: 2, character: 'b' }
@@ -203,7 +203,7 @@ RSpec.describe 'Api::FileItems', type: :request do
         updated_file_item = FileItem.find(untyped_file_item.id)
         expect(updated_file_item.typing_progress.row).to eq(3)
         expect(updated_file_item.typing_progress.column).to eq(1)
-        expect(updated_file_item.typing_progress.time).to eq(330.5)
+        expect(updated_file_item.typing_progress.elapsed_seconds).to eq(330)
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
 
         expect(updated_file_item.typing_progress.typos.length).to eq(2)
@@ -238,7 +238,6 @@ RSpec.describe 'Api::FileItems', type: :request do
         json = response.parsed_body
         expect(json['typing_progress.row']).to include("can't be blank")
         expect(json['typing_progress.column']).to include("can't be blank")
-        expect(json['typing_progress.time']).to include("can't be blank")
 
         # status: typing
         patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
@@ -248,7 +247,6 @@ RSpec.describe 'Api::FileItems', type: :request do
         json = response.parsed_body
         expect(json['typing_progress.row']).to include("can't be blank")
         expect(json['typing_progress.column']).to include("can't be blank")
-        expect(json['typing_progress.time']).to include("can't be blank")
       end
     end
 

--- a/backend/spec/requests/api/repositories_spec.rb
+++ b/backend/spec/requests/api/repositories_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Api::Repositories', type: :request do
           expect(repository_json).to have_json_attributes(
             name: repository.name,
             user_id: repository.user_id,
-            last_typed_at: repository.last_typed_at&.as_json,
+            last_typed_at: repository.last_typed_at,
             progress: 0.4
           )
         end

--- a/backend/spec/requests/api/repositories_spec.rb
+++ b/backend/spec/requests/api/repositories_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Api::Repositories', type: :request do
         json = response.parsed_body
         expect(response).to have_http_status(:ok)
         expect(json.length).to eq(3)
-        expect(json.map { |r| r['id'] }).to match_array(repositories.map(&:id))
+        expect(json.pluck('id')).to match_array(repositories.map(&:id))
 
         repositories.each do |repository|
           repository_json = json.find { |r| r['id'] == repository.id }

--- a/frontend/__tests__/hooks/useTypingHandler.test.ts
+++ b/frontend/__tests__/hooks/useTypingHandler.test.ts
@@ -45,7 +45,9 @@ describe('useTypingHandler', () => {
     const { result } = renderHook(() => useTypingHandler(props));
     await act(async () => {
       await result.current.setupTypingState(1);
+      result.current.startTyping();
     });
+
     return result;
   };
 
@@ -426,6 +428,7 @@ describe('useTypingHandler', () => {
         jest.spyOn(axios, 'patch').mockResolvedValueOnce(mockResponse);
 
         const result = await setupHook(typingProps);
+
         await userEvent.keyboard('def hello_world{Enter}');
         await userEvent.keyboard('pust');
 
@@ -535,6 +538,7 @@ describe('useTypingHandler', () => {
         jest.spyOn(axios, 'patch').mockRejectedValueOnce(new Error('Server Error'));
 
         const result = await setupHook(typingProps);
+
         await typeEntireContent();
 
         expect(result.current.errorMessage).toBe('An error occurred. Please try again.');
@@ -693,6 +697,7 @@ describe('useTypingHandler', () => {
         (sortFileItems as jest.Mock).mockReturnValue(sortedResponse);
 
         await setupHook(typingProps);
+
         await typeEntireContent();
       });
 

--- a/frontend/__tests__/hooks/useTypingHandler.test.ts
+++ b/frontend/__tests__/hooks/useTypingHandler.test.ts
@@ -445,8 +445,9 @@ describe('useTypingHandler', () => {
               typingProgress: {
                 row: 1,
                 column: 6,
-                time: 100.5,
-                totalTypoCount: 10,
+                elapsedSeconds: 0,
+                totalCorrectTypeCount: 18,
+                totalTypoCount: 2,
                 typosAttributes: [
                   {
                     row: 1,
@@ -706,8 +707,9 @@ describe('useTypingHandler', () => {
               typingProgress: {
                 row: 2,
                 column: 3,
-                time: 100.5,
-                totalTypoCount: 10,
+                elapsedSeconds: 0,
+                totalCorrectTypeCount: 38,
+                totalTypoCount: 2,
                 typosAttributes: [
                   {
                     row: 1,

--- a/frontend/__tests__/hooks/useTypingStats.test.tsx
+++ b/frontend/__tests__/hooks/useTypingStats.test.tsx
@@ -1,0 +1,276 @@
+import { useTypingStats } from '@/hooks/useTypingStats';
+import { act, renderHook } from '@testing-library/react';
+
+describe('useTypingStats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('initial state', () => {
+    it('sets accuracy to 100% and other stats to 0', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      expect(result.current.accuracy).toBe(100);
+      expect(result.current.totalCorrectTypeCount).toBe(0);
+      expect(result.current.elapsedSeconds).toBe(0);
+      expect(result.current.totalTypoCount).toBe(0);
+      expect(result.current.wpm).toBe(0);
+    });
+  });
+
+  describe('during typing', () => {
+    it('updates statistics', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        result.current.startStats();
+      });
+
+      act(() => {
+        [...Array(2)].forEach(() => result.current.updateStats(true));
+        result.current.updateStats(false);
+      });
+
+      expect(result.current.accuracy).toBe(66.7);
+      expect(result.current.totalCorrectTypeCount).toBe(2);
+      expect(result.current.totalTypoCount).toBe(1);
+    });
+
+    it('updates statistics over time', () => {
+      const mockPerformanceNow = jest.spyOn(performance, 'now');
+      try {
+        mockPerformanceNow.mockReturnValue(1000); // 現在の時間を1秒にモック
+        const { result } = renderHook(() => useTypingStats());
+
+        act(() => {
+          result.current.startStats();
+        });
+
+        act(() => {
+          [...Array(5)].forEach(() => result.current.updateStats(true));
+        });
+
+        mockPerformanceNow.mockReturnValue(61000); // 60秒経過させるようにモック
+        act(() => {
+          jest.advanceTimersByTime(1000); // タイマーの計測が1秒間隔のため1秒経過させる
+        });
+
+        expect(result.current.wpm).toBe(1.0);
+        expect(result.current.elapsedSeconds).toBe(60);
+      } finally {
+        mockPerformanceNow.mockRestore();
+      }
+    });
+
+    it('can pause and keep statistics', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      const mockPerformanceNow = jest.spyOn(performance, 'now');
+      try {
+        mockPerformanceNow.mockReturnValue(1000);
+
+        act(() => {
+          result.current.startStats();
+        });
+
+        act(() => {
+          result.current.updateStats(true);
+          result.current.updateStats(false);
+        });
+
+        mockPerformanceNow.mockReturnValue(2000);
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ポーズ前の統計情報の確認
+        expect(result.current.accuracy).toBe(50.0);
+        expect(result.current.elapsedSeconds).toBe(1);
+        expect(result.current.totalCorrectTypeCount).toBe(1);
+        expect(result.current.totalTypoCount).toBe(1);
+        expect(result.current.wpm).toBe(12);
+
+        act(() => {
+          result.current.pauseStats();
+        });
+
+        mockPerformanceNow.mockReturnValue(3000);
+
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ポーズ後に統計情報が更新されないことを確認
+        expect(result.current.accuracy).toBe(50.0);
+        expect(result.current.elapsedSeconds).toBe(1);
+        expect(result.current.totalCorrectTypeCount).toBe(1);
+        expect(result.current.totalTypoCount).toBe(1);
+        expect(result.current.wpm).toBe(12);
+      } finally {
+        mockPerformanceNow.mockRestore();
+      }
+    });
+
+    it('can resume after pause', () => {
+      const mockPerformanceNow = jest.spyOn(performance, 'now');
+      try {
+        mockPerformanceNow.mockReturnValue(1000);
+
+        const { result } = renderHook(() => useTypingStats());
+
+        act(() => {
+          result.current.startStats();
+        });
+
+        mockPerformanceNow.mockReturnValue(2000);
+
+        act(() => {
+          result.current.updateStats(true);
+          result.current.updateStats(false);
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ポーズ前の統計情報と時間を確認
+        expect(result.current.accuracy).toBe(50.0);
+        expect(result.current.elapsedSeconds).toBe(1);
+        expect(result.current.totalCorrectTypeCount).toBe(1);
+        expect(result.current.totalTypoCount).toBe(1);
+        expect(result.current.wpm).toBe(12);
+
+        // ポーズして再開する
+        act(() => {
+          result.current.pauseStats();
+        });
+
+        mockPerformanceNow.mockReturnValue(3000);
+
+        act(() => {
+          result.current.resumeStats();
+        });
+
+        mockPerformanceNow.mockReturnValue(4000);
+
+        act(() => {
+          result.current.updateStats(true);
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ポーズ前の統計上を引き継いで更新されることを確認
+        expect(result.current.accuracy).toBe(66.7);
+        expect(result.current.elapsedSeconds).toBe(2);
+        expect(result.current.totalCorrectTypeCount).toBe(2);
+        expect(result.current.totalTypoCount).toBe(1);
+        expect(result.current.wpm).toBe(12);
+      } finally {
+        mockPerformanceNow.mockRestore();
+      }
+    });
+
+    it('can reset', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        result.current.startStats();
+        result.current.updateStats(true);
+        result.current.updateStats(false);
+        result.current.resetStats();
+      });
+
+      expect(result.current.accuracy).toBe(100);
+      expect(result.current.totalCorrectTypeCount).toBe(0);
+      expect(result.current.elapsedSeconds).toBe(0);
+      expect(result.current.totalTypoCount).toBe(0);
+      expect(result.current.wpm).toBe(0);
+    });
+  });
+
+  describe('during not typing', () => {
+    it('does not update statistics when typing', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        result.current.updateStats(true);
+        result.current.updateStats(false);
+      });
+
+      expect(result.current.accuracy).toBe(100);
+      expect(result.current.totalCorrectTypeCount).toBe(0);
+      expect(result.current.totalTypoCount).toBe(0);
+    });
+
+    it('does not update statistics over time', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.elapsedSeconds).toBe(0);
+      expect(result.current.wpm).toBe(0);
+    });
+
+    it('can start', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        result.current.startStats();
+      });
+
+      expect(result.current.accuracy).toBe(100);
+      expect(result.current.totalCorrectTypeCount).toBe(0);
+      expect(result.current.elapsedSeconds).toBe(0);
+      expect(result.current.totalTypoCount).toBe(0);
+      expect(result.current.wpm).toBe(0);
+    });
+
+    it('can reset', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      act(() => {
+        result.current.resetStats();
+      });
+
+      expect(result.current.accuracy).toBe(100);
+      expect(result.current.totalCorrectTypeCount).toBe(0);
+      expect(result.current.elapsedSeconds).toBe(0);
+      expect(result.current.totalTypoCount).toBe(0);
+      expect(result.current.wpm).toBe(0);
+    });
+  });
+
+  describe('restoreStats', () => {
+    it('restores saved statistics', () => {
+      const { result } = renderHook(() => useTypingStats());
+
+      const savedStats = {
+        accuracy: 85.0,
+        elapsedSeconds: 120,
+        totalCorrectTypeCount: 17,
+        totalTypoCount: 3,
+        wpm: 8.0,
+      };
+
+      act(() => {
+        result.current.restoreStats(
+          savedStats.accuracy,
+          savedStats.elapsedSeconds,
+          savedStats.totalCorrectTypeCount,
+          savedStats.totalTypoCount,
+          savedStats.wpm,
+        );
+      });
+
+      expect(result.current.accuracy).toBe(85.0);
+      expect(result.current.totalCorrectTypeCount).toBe(17);
+      expect(result.current.elapsedSeconds).toBe(120);
+      expect(result.current.totalTypoCount).toBe(3);
+      expect(result.current.wpm).toBe(8.0);
+    });
+  });
+});

--- a/frontend/src/components/repositories/FileTree.tsx
+++ b/frontend/src/components/repositories/FileTree.tsx
@@ -1,4 +1,4 @@
-import { FileItem } from '@/types';
+import type { FileItem } from '@/types';
 import FileTreeItem from './FileTreeItem';
 
 type FileTreeProps = {

--- a/frontend/src/components/repositories/FileTreeItem.tsx
+++ b/frontend/src/components/repositories/FileTreeItem.tsx
@@ -3,7 +3,7 @@
 import { Check, ChevronDown, ChevronRight, File, Folder } from 'lucide-react';
 import { useState } from 'react';
 
-import { FileItem } from '@/types';
+import type { FileItem } from '@/types';
 import { sortFileItems } from '@/utils/sort';
 
 type FileTreeItemProps = {

--- a/frontend/src/components/repositories/RepositoryDetail.tsx
+++ b/frontend/src/components/repositories/RepositoryDetail.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 import { useTypingHandler } from '@/hooks/useTypingHandler';
-import { FileItem, TypingStatus } from '@/types';
+import type { FileItem, TypingStatus } from '@/types';
 import { Card } from '../ui/card';
 import Loading from '../ui/loading';
 import FileTree from './FileTree';

--- a/frontend/src/components/repositories/TypingContent.tsx
+++ b/frontend/src/components/repositories/TypingContent.tsx
@@ -1,5 +1,5 @@
 import TypingLine from '@/components/repositories/TypingLine';
-import { TypingStatus } from '@/types';
+import type { TypingStatus } from '@/types';
 
 type TypingContentProps = {
   cursorRow: number;

--- a/frontend/src/components/repositories/TypingHeader.tsx
+++ b/frontend/src/components/repositories/TypingHeader.tsx
@@ -1,7 +1,7 @@
 import { Pause, Play, RotateCcw } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { TypingStatus } from '@/types';
+import type { TypingStatus } from '@/types';
 
 type TypingHeaderProps = {
   fileItemName: string;

--- a/frontend/src/components/repositories/TypingPanel.tsx
+++ b/frontend/src/components/repositories/TypingPanel.tsx
@@ -1,4 +1,4 @@
-import { FileItem, TypingStatus } from '@/types';
+import { FileItem, Stats, TypingStatus } from '@/types';
 import TypingContent from './TypingContent';
 import TypingHeader from './TypingHeader';
 import TypingStats from './TypingStats';
@@ -15,11 +15,7 @@ type TypingPanelProps = {
     resumeTyping: () => void;
     pauseTyping: () => void;
     resetTyping: () => void;
-    accuracy: number;
-    correctTypeCount: number;
-    elapsedSeconds: number;
-    typoCount: number;
-    wpm: number;
+    stats: Stats;
   };
 };
 
@@ -30,14 +26,11 @@ export default function TypingPanel({ fileItem, typingHandler }: TypingPanelProp
     targetTextLines,
     typedTextLines,
     typingStatus,
+    stats,
     startTyping,
     resetTyping,
     pauseTyping,
     resumeTyping,
-    accuracy,
-    elapsedSeconds,
-    typoCount,
-    wpm,
   } = typingHandler;
 
   return (
@@ -58,9 +51,7 @@ export default function TypingPanel({ fileItem, typingHandler }: TypingPanelProp
           typedTextLines={typedTextLines}
           typingStatus={typingStatus}
         />
-        {(typingStatus === 'typing' || typingStatus === 'paused') && (
-          <TypingStats accuracy={accuracy} elapsedSeconds={elapsedSeconds} typoCount={typoCount} wpm={wpm} />
-        )}
+        {(typingStatus === 'typing' || typingStatus === 'paused') && <TypingStats stats={stats} />}
       </div>
     </div>
   );

--- a/frontend/src/components/repositories/TypingPanel.tsx
+++ b/frontend/src/components/repositories/TypingPanel.tsx
@@ -1,6 +1,7 @@
 import { FileItem, TypingStatus } from '@/types';
 import TypingContent from './TypingContent';
 import TypingHeader from './TypingHeader';
+import TypingStats from './TypingStats';
 
 type TypingPanelProps = {
   fileItem: FileItem;
@@ -14,6 +15,11 @@ type TypingPanelProps = {
     resumeTyping: () => void;
     pauseTyping: () => void;
     resetTyping: () => void;
+    accuracy: number;
+    correctTypeCount: number;
+    elapsedSeconds: number;
+    typoCount: number;
+    wpm: number;
   };
 };
 
@@ -28,6 +34,10 @@ export default function TypingPanel({ fileItem, typingHandler }: TypingPanelProp
     resetTyping,
     pauseTyping,
     resumeTyping,
+    accuracy,
+    elapsedSeconds,
+    typoCount,
+    wpm,
   } = typingHandler;
 
   return (
@@ -40,7 +50,7 @@ export default function TypingPanel({ fileItem, typingHandler }: TypingPanelProp
         resumeTyping={resumeTyping}
         resetTyping={resetTyping}
       />
-      <div className="flex-1 overflow-hidden">
+      <div className="relative flex-1 overflow-hidden">
         <TypingContent
           cursorRow={cursorRow}
           cursorColumns={cursorColumns}
@@ -48,6 +58,9 @@ export default function TypingPanel({ fileItem, typingHandler }: TypingPanelProp
           typedTextLines={typedTextLines}
           typingStatus={typingStatus}
         />
+        {(typingStatus === 'typing' || typingStatus === 'paused') && (
+          <TypingStats accuracy={accuracy} elapsedSeconds={elapsedSeconds} typoCount={typoCount} wpm={wpm} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/repositories/TypingPanel.tsx
+++ b/frontend/src/components/repositories/TypingPanel.tsx
@@ -1,4 +1,4 @@
-import { FileItem, Stats, TypingStatus } from '@/types';
+import type { FileItem, Stats, TypingStatus } from '@/types';
 import TypingContent from './TypingContent';
 import TypingHeader from './TypingHeader';
 import TypingStats from './TypingStats';

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -1,0 +1,37 @@
+type TypingStatsProps = {
+  accuracy: number;
+  elapsedSeconds: number;
+  typoCount: number;
+  wpm: number;
+};
+
+export default function TypingStats({ accuracy, elapsedSeconds, typoCount, wpm }: TypingStatsProps) {
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="bg-background/80 absolute right-4 bottom-4 rounded-lg border px-3 py-2 text-sm backdrop-blur-sm">
+      <div className="flex min-w-[120px] flex-col gap-1">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Accuracy:</span>
+          <span>{accuracy}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Time:</span>
+          <span>{formatTime(elapsedSeconds)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Typos:</span>
+          <span>{typoCount}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">WPM:</span>
+          <span>{wpm}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -18,7 +18,7 @@ export default function TypingStats({ stats }: TypingStatsProps) {
       <div className="flex min-w-[120px] flex-col gap-1">
         <div className="flex justify-between">
           <span className="text-muted-foreground">Accuracy:</span>
-          <span>{accuracy}%</span>
+          <span>{accuracy.toFixed(1)}%</span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">Time:</span>
@@ -30,7 +30,7 @@ export default function TypingStats({ stats }: TypingStatsProps) {
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">WPM:</span>
-          <span>{wpm}</span>
+          <span>{wpm.toFixed(1)}</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -1,11 +1,12 @@
+import { Stats } from '@/types';
+
 type TypingStatsProps = {
-  accuracy: number;
-  elapsedSeconds: number;
-  typoCount: number;
-  wpm: number;
+  stats: Stats;
 };
 
-export default function TypingStats({ accuracy, elapsedSeconds, typoCount, wpm }: TypingStatsProps) {
+export default function TypingStats({ stats }: TypingStatsProps) {
+  const { accuracy, elapsedSeconds, typoCount, wpm } = stats;
+
   const formatTime = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = seconds % 60;

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -18,19 +18,19 @@ export default function TypingStats({ stats }: TypingStatsProps) {
       <div className="flex min-w-[120px] flex-col gap-1">
         <div className="flex justify-between">
           <span className="text-muted-foreground">Accuracy:</span>
-          <span>{accuracy.toFixed(1)}%</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">Time:</span>
-          <span>{formatTime(elapsedSeconds)}</span>
+          <span>{accuracy?.toFixed(1) || '0.0'}%</span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">Typos:</span>
-          <span>{totalTypoCount}</span>
+          <span>{totalTypoCount || 0}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">WPM:</span>
-          <span>{wpm.toFixed(1)}</span>
+          <span>{wpm?.toFixed(1) || '0.0'}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Time:</span>
+          <span>{formatTime(elapsedSeconds || 0)}</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -1,4 +1,4 @@
-import { Stats } from '@/types';
+import type { Stats } from '@/types';
 
 type TypingStatsProps = {
   stats: Stats;

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -15,7 +15,7 @@ export default function TypingStats({ stats }: TypingStatsProps) {
 
   return (
     <div className="bg-background/80 absolute right-4 bottom-4 rounded-lg border px-3 py-2 text-sm backdrop-blur-sm">
-      <div className="flex min-w-[120px] flex-col gap-1">
+      <div className="flex min-w-[140px] flex-col gap-1">
         <div className="flex justify-between">
           <span className="text-muted-foreground">Accuracy:</span>
           <span>{accuracy?.toFixed(1) || '0.0'}%</span>

--- a/frontend/src/components/repositories/TypingStats.tsx
+++ b/frontend/src/components/repositories/TypingStats.tsx
@@ -5,7 +5,7 @@ type TypingStatsProps = {
 };
 
 export default function TypingStats({ stats }: TypingStatsProps) {
-  const { accuracy, elapsedSeconds, typoCount, wpm } = stats;
+  const { accuracy, elapsedSeconds, totalTypoCount, wpm } = stats;
 
   const formatTime = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);
@@ -26,7 +26,7 @@ export default function TypingStats({ stats }: TypingStatsProps) {
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">Typos:</span>
-          <span>{typoCount}</span>
+          <span>{totalTypoCount}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">WPM:</span>

--- a/frontend/src/components/repositories/index/RepositoryList.tsx
+++ b/frontend/src/components/repositories/index/RepositoryList.tsx
@@ -2,7 +2,7 @@ import { FolderOpen, Plus } from 'lucide-react';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
-import { PaginationInfo, Repository } from '@/types/repository';
+import type { PaginationInfo, Repository } from '@/types/repository';
 import RepositoryListItem from './RepositoryListItem';
 import RepositoryPagination from './RepositoryPagination';
 

--- a/frontend/src/components/repositories/index/RepositoryListItem.tsx
+++ b/frontend/src/components/repositories/index/RepositoryListItem.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Repository } from '@/types/repository';
+import type { Repository } from '@/types/repository';
 import RepositoryProgress from './RepositoryProgress';
 
 type Props = {

--- a/frontend/src/components/repositories/index/RepositoryPagination.tsx
+++ b/frontend/src/components/repositories/index/RepositoryPagination.tsx
@@ -10,7 +10,7 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 import { PAGINATION } from '@/constants/pagination';
-import { PaginationInfo } from '@/types/repository';
+import type { PaginationInfo } from '@/types/repository';
 import { useSearchParams } from 'next/navigation';
 
 type Props = {

--- a/frontend/src/components/repositories/new/RepositoryCreationWizard.tsx
+++ b/frontend/src/components/repositories/new/RepositoryCreationWizard.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { WizardData, WizardStep } from '@/types';
+import type { WizardData, WizardStep } from '@/types';
 import CreationConfirmStep from './steps/CreationConfirmStep';
 import ExtensionSelectionStep from './steps/ExtensionSelectionStep';
 import UrlInputStep from './steps/UrlInputStep';

--- a/frontend/src/components/repositories/new/steps/CreationConfirmStep.tsx
+++ b/frontend/src/components/repositories/new/steps/CreationConfirmStep.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { WizardData } from '@/types';
+import type { WizardData } from '@/types';
 import { axiosPost } from '@/utils/axios';
 import RepositoryCard from '../common/RepositoryCard';
 

--- a/frontend/src/components/repositories/new/steps/ExtensionSelectionStep.tsx
+++ b/frontend/src/components/repositories/new/steps/ExtensionSelectionStep.tsx
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Extension, RepositoryPreview, WizardData } from '@/types';
+import type { Extension, RepositoryPreview, WizardData } from '@/types';
 import RepositoryCard from '../common/RepositoryCard';
 
 type ExtensionSelectionStepProps = {

--- a/frontend/src/components/repositories/new/steps/UrlInputStep.tsx
+++ b/frontend/src/components/repositories/new/steps/UrlInputStep.tsx
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { RepositoryPreview, WizardData } from '@/types';
+import type { RepositoryPreview, WizardData } from '@/types';
 import { axiosGet } from '@/utils/axios';
 
 type FormValues = {

--- a/frontend/src/hooks/useTypingHandler.ts
+++ b/frontend/src/hooks/useTypingHandler.ts
@@ -99,8 +99,8 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
             row: cursorRow,
             column: cursorColumns[cursorRow],
             elapsedSeconds: typingStats.elapsedSeconds,
-            totalCorrectTypeCount: typingStats.correctTypeCount,
-            totalTypoCount: typingStats.typoCount,
+            totalCorrectTypeCount: typingStats.totalCorrectTypeCount,
+            totalTypoCount: typingStats.totalTypoCount,
             typosAttributes: calculateTypos(typedTextLines, targetTextLines),
           },
         },
@@ -144,8 +144,8 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
             row: cursorRow,
             column: cursorColumns[cursorRow],
             elapsedSeconds: typingStats.elapsedSeconds,
-            totalCorrectTypeCount: typingStats.correctTypeCount,
-            totalTypoCount: typingStats.typoCount,
+            totalCorrectTypeCount: typingStats.totalCorrectTypeCount,
+            totalTypoCount: typingStats.totalTypoCount,
             typosAttributes: calculateTypos(typedTextLines, targetTextLines),
           },
         },
@@ -268,9 +268,9 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
 
   const stats: Stats = {
     accuracy: typingStats.accuracy,
-    correctTypeCount: typingStats.correctTypeCount,
+    totalCorrectTypeCount: typingStats.totalCorrectTypeCount,
     elapsedSeconds: typingStats.elapsedSeconds,
-    typoCount: typingStats.typoCount,
+    totalTypoCount: typingStats.totalTypoCount,
     wpm: typingStats.wpm,
   };
 

--- a/frontend/src/hooks/useTypingHandler.ts
+++ b/frontend/src/hooks/useTypingHandler.ts
@@ -70,8 +70,8 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
       setTypedTextLines(restoredTypedTextLines);
       setCursorRow(currentRow);
 
-      const { accuracy, totalCorrectTypeCount, elapsedSeconds, totalTypoCount, wpm } = fetchedFileItem.typingProgress;
-      typingStats.restoreStats(accuracy, totalCorrectTypeCount, elapsedSeconds, totalTypoCount, wpm);
+      const { accuracy, elapsedSeconds, totalCorrectTypeCount, totalTypoCount, wpm } = fetchedFileItem.typingProgress;
+      typingStats.restoreStats(accuracy, elapsedSeconds, totalCorrectTypeCount, totalTypoCount, wpm);
     } catch (error) {
       if (axios.isAxiosError(error)) {
         setErrorMessage(error.message);
@@ -268,8 +268,8 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
 
   const stats: Stats = {
     accuracy: typingStats.accuracy,
-    totalCorrectTypeCount: typingStats.totalCorrectTypeCount,
     elapsedSeconds: typingStats.elapsedSeconds,
+    totalCorrectTypeCount: typingStats.totalCorrectTypeCount,
     totalTypoCount: typingStats.totalTypoCount,
     wpm: typingStats.wpm,
   };

--- a/frontend/src/hooks/useTypingHandler.ts
+++ b/frontend/src/hooks/useTypingHandler.ts
@@ -70,12 +70,8 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
       setTypedTextLines(restoredTypedTextLines);
       setCursorRow(currentRow);
 
-      const savedAccuracy = fetchedFileItem.typingProgress.accuracy;
-      const savedElapsedSeconds = fetchedFileItem.typingProgress.elapsedSeconds;
-      const savedCorrectTypeCount = fetchedFileItem.typingProgress.totalCorrectTypeCount;
-      const savedTypoCount = fetchedFileItem.typingProgress.totalTypoCount;
-      const savedWpm = fetchedFileItem.typingProgress.wpm;
-      stats.restoreStats(savedAccuracy, savedCorrectTypeCount, savedElapsedSeconds, savedTypoCount, savedWpm);
+      const { accuracy, totalCorrectTypeCount, elapsedSeconds, totalTypoCount, wpm } = fetchedFileItem.typingProgress;
+      stats.restoreStats(accuracy, totalCorrectTypeCount, elapsedSeconds, totalTypoCount, wpm);
     } catch (error) {
       if (axios.isAxiosError(error)) {
         setErrorMessage(error.message);
@@ -174,9 +170,9 @@ export function useTypingHandler({ typingStatus, fileItem, setFileItems, setTypi
     cursorColumns,
     typedTextLines,
     targetTextLines,
+    stats,
     setFileItems,
     setTypingStatus,
-    stats,
   ]);
 
   const isComplete = useCallback(

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type TypingStatsData = {
+  accuracy: number;
+  correctTypeCount: number;
+  elapsedSeconds: number;
+  typoCount: number;
+  wpm: number;
+};
+
+type TypingStatsActions = {
+  startStats: () => void;
+  pauseStats: () => void;
+  resumeStats: () => void;
+  resetStats: () => void;
+  updateStats: (isCorrect: boolean) => void;
+  restoreStats: (
+    savedAccuracy: number,
+    savedCorrectTypeCount: number,
+    savedElapsedSeconds: number,
+    savedTypoCount: number,
+    savedWpm: number,
+  ) => void;
+};
+
+export function useTypingStats(): TypingStatsData & TypingStatsActions {
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [accumulatedSeconds, setAccumulatedSeconds] = useState(0);
+  const [wpm, setWpm] = useState(0);
+  const [typoCount, setTypoCount] = useState(0);
+  const [correctTypeCount, setCorrectTypeCount] = useState(0);
+  const [isTyping, setIsTyping] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [accuracy, setAccuracy] = useState(100);
+
+  useEffect(() => {
+    console.log('ACCUMULATED TIME', accumulatedSeconds);
+
+    const interval = setInterval(() => {
+      if (!isTyping || !startTime) return;
+
+      const newElapsedSeconds = accumulatedSeconds + Math.floor((Date.now() - startTime) / 1000);
+      setElapsedSeconds(newElapsedSeconds);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isTyping, startTime, accumulatedSeconds]);
+
+  useEffect(() => {
+    if (!isTyping || !startTime || correctTypeCount === 0 || elapsedSeconds === 0) return;
+
+    const elapsedMinutes = elapsedSeconds / 60;
+    const newWpm = Math.round(correctTypeCount / 5 / elapsedMinutes);
+    setWpm(newWpm);
+  }, [isTyping, startTime, elapsedSeconds, correctTypeCount]);
+
+  useEffect(() => {
+    const totalTypeCount = correctTypeCount + typoCount;
+    if (totalTypeCount > 0) {
+      const newAccuracy = Math.round((correctTypeCount / totalTypeCount) * 100);
+      setAccuracy(newAccuracy);
+    } else {
+      setAccuracy(100);
+    }
+  }, [correctTypeCount, typoCount]);
+
+  const startStats = useCallback(() => {
+    setStartTime(Date.now());
+    setAccumulatedSeconds(0);
+    setWpm(0);
+    setTypoCount(0);
+    setCorrectTypeCount(0);
+    setElapsedSeconds(0);
+    setAccuracy(100);
+    setIsTyping(true);
+  }, []);
+
+  const pauseStats = useCallback(() => {
+    setAccumulatedSeconds(elapsedSeconds);
+    setStartTime(null);
+    setIsTyping(false);
+  }, [elapsedSeconds]);
+
+  const resumeStats = useCallback(() => {
+    setStartTime(Date.now());
+    setIsTyping(true);
+  }, []);
+
+  const resetStats = useCallback(() => {
+    setStartTime(null);
+    setAccumulatedSeconds(0);
+    setWpm(0);
+    setAccuracy(100);
+    setTypoCount(0);
+    setCorrectTypeCount(0);
+    setElapsedSeconds(0);
+    setIsTyping(false);
+  }, []);
+
+  const updateStats = useCallback((isCorrect: boolean) => {
+    if (isCorrect) {
+      setCorrectTypeCount((prev) => prev + 1);
+    } else {
+      setTypoCount((prev) => prev + 1);
+    }
+  }, []);
+
+  const restoreStats = useCallback(
+    (
+      savedAccuracy: number,
+      savedCorrectTypeCount: number,
+      savedElapsedSeconds: number,
+      savedTypoCount: number,
+      savedWpm: number,
+    ) => {
+      const timeInSeconds = Math.floor(savedElapsedSeconds);
+      setAccumulatedSeconds(timeInSeconds);
+      setElapsedSeconds(timeInSeconds);
+      setTypoCount(savedTypoCount);
+      setCorrectTypeCount(savedCorrectTypeCount);
+      setWpm(savedWpm);
+      setStartTime(null);
+
+      setAccuracy(savedAccuracy);
+
+      setIsTyping(false);
+    },
+    [],
+  );
+
+  return {
+    accuracy,
+    correctTypeCount,
+    elapsedSeconds,
+    typoCount,
+    wpm,
+    startStats,
+    pauseStats,
+    resumeStats,
+    resetStats,
+    updateStats,
+    restoreStats,
+  };
+}

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -91,7 +91,6 @@ export function useTypingStats() {
       savedTypoCount: number,
       savedWpm: number,
     ) => {
-      console.log('restoreStats', savedAccuracy, savedCorrectTypeCount, savedElapsedSeconds, savedTypoCount, savedWpm);
       setAccuracy(savedAccuracy);
       setTotalCorrectTypeCount(savedCorrectTypeCount);
       setElapsedSeconds(savedElapsedSeconds);

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -4,8 +4,8 @@ import { Stats } from '@/types';
 
 export function useTypingStats() {
   const [accuracy, setAccuracy] = useState(100);
-  const [totalCorrectTypeCount, setTotalCorrectTypeCount] = useState(0);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [totalCorrectTypeCount, setTotalCorrectTypeCount] = useState(0);
   const [totalTypoCount, setTotalTypoCount] = useState(0);
   const [wpm, setWpm] = useState(0);
   const lastMeasureTimeRef = useRef<number | null>(null);
@@ -86,14 +86,14 @@ export function useTypingStats() {
   const restoreStats = useCallback(
     (
       savedAccuracy: number,
-      savedCorrectTypeCount: number,
       savedElapsedSeconds: number,
+      savedCorrectTypeCount: number,
       savedTypoCount: number,
       savedWpm: number,
     ) => {
       setAccuracy(savedAccuracy);
-      setTotalCorrectTypeCount(savedCorrectTypeCount);
       setElapsedSeconds(savedElapsedSeconds);
+      setTotalCorrectTypeCount(savedCorrectTypeCount);
       setTotalTypoCount(savedTypoCount);
       setWpm(savedWpm);
       lastMeasureTimeRef.current = null;
@@ -104,8 +104,8 @@ export function useTypingStats() {
 
   const stats: Stats = {
     accuracy,
-    totalCorrectTypeCount,
     elapsedSeconds,
+    totalCorrectTypeCount,
     totalTypoCount,
     wpm,
   };

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -33,6 +33,8 @@ export function useTypingStats() {
   }, [isTyping, elapsedSeconds, totalCorrectTypeCount]);
 
   useEffect(() => {
+    if (!isTyping) return;
+
     const totalTypeCount = totalCorrectTypeCount + totalTypoCount;
     if (totalTypeCount > 0) {
       const newAccuracy = Math.round((totalCorrectTypeCount / totalTypeCount) * 1000) / 10;
@@ -40,7 +42,7 @@ export function useTypingStats() {
     } else {
       setAccuracy(100);
     }
-  }, [totalCorrectTypeCount, totalTypoCount]);
+  }, [isTyping, totalCorrectTypeCount, totalTypoCount]);
 
   const startStats = useCallback(() => {
     setAccuracy(100);

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -28,14 +28,14 @@ export function useTypingStats() {
     if (!isTyping || !lastMeasureTimeRef.current || totalCorrectTypeCount === 0 || elapsedSeconds === 0) return;
 
     const elapsedMinutes = elapsedSeconds / 60;
-    const newWpm = Math.round(totalCorrectTypeCount / 5 / elapsedMinutes);
+    const newWpm = Math.round((totalCorrectTypeCount / 5 / elapsedMinutes) * 10) / 10;
     setWpm(newWpm);
   }, [isTyping, elapsedSeconds, totalCorrectTypeCount]);
 
   useEffect(() => {
     const totalTypeCount = totalCorrectTypeCount + totalTypoCount;
     if (totalTypeCount > 0) {
-      const newAccuracy = Math.round((totalCorrectTypeCount / totalTypeCount) * 100);
+      const newAccuracy = Math.round((totalCorrectTypeCount / totalTypeCount) * 1000) / 10;
       setAccuracy(newAccuracy);
     } else {
       setAccuracy(100);

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -45,6 +45,8 @@ export function useTypingStats() {
   }, [isTyping, totalCorrectTypeCount, totalTypoCount]);
 
   const startStats = useCallback(() => {
+    if (isTyping) return;
+
     setAccuracy(100);
     setTotalCorrectTypeCount(0);
     setElapsedSeconds(0);
@@ -52,17 +54,21 @@ export function useTypingStats() {
     setWpm(0);
     lastMeasureTimeRef.current = performance.now();
     setIsTyping(true);
-  }, []);
+  }, [isTyping]);
 
   const pauseStats = useCallback(() => {
+    if (!isTyping) return;
+
     lastMeasureTimeRef.current = null;
     setIsTyping(false);
-  }, []);
+  }, [isTyping]);
 
   const resumeStats = useCallback(() => {
+    if (isTyping) return;
+
     lastMeasureTimeRef.current = performance.now();
     setIsTyping(true);
-  }, []);
+  }, [isTyping]);
 
   const resetStats = useCallback(() => {
     setAccuracy(100);
@@ -76,13 +82,15 @@ export function useTypingStats() {
 
   const updateStats = useCallback(
     (isCorrect: boolean) => {
+      if (!isTyping) return;
+
       if (isCorrect) {
         setTotalCorrectTypeCount((prev) => prev + 1);
       } else {
         setTotalTypoCount((prev) => prev + 1);
       }
     },
-    [setTotalCorrectTypeCount, setTotalTypoCount],
+    [isTyping, setTotalCorrectTypeCount, setTotalTypoCount],
   );
 
   const restoreStats = useCallback(

--- a/frontend/src/hooks/useTypingStats.ts
+++ b/frontend/src/hooks/useTypingStats.ts
@@ -1,29 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type TypingStatsData = {
-  accuracy: number;
-  correctTypeCount: number;
-  elapsedSeconds: number;
-  typoCount: number;
-  wpm: number;
-};
+import { Stats } from '@/types';
 
-type TypingStatsActions = {
-  startStats: () => void;
-  pauseStats: () => void;
-  resumeStats: () => void;
-  resetStats: () => void;
-  updateStats: (isCorrect: boolean) => void;
-  restoreStats: (
-    savedAccuracy: number,
-    savedCorrectTypeCount: number,
-    savedElapsedSeconds: number,
-    savedTypoCount: number,
-    savedWpm: number,
-  ) => void;
-};
-
-export function useTypingStats(): TypingStatsData & TypingStatsActions {
+export function useTypingStats() {
   const [accuracy, setAccuracy] = useState(100);
   const [correctTypeCount, setCorrectTypeCount] = useState(0);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
@@ -123,12 +102,16 @@ export function useTypingStats(): TypingStatsData & TypingStatsActions {
     [setAccuracy, setCorrectTypeCount, setElapsedSeconds, setTypoCount, setWpm, setLastMeasureTime, setIsTyping],
   );
 
-  return {
+  const stats: Stats = {
     accuracy,
     correctTypeCount,
     elapsedSeconds,
     typoCount,
     wpm,
+  };
+
+  return {
+    ...stats,
     startStats,
     pauseStats,
     resumeStats,

--- a/frontend/src/types/file-item.ts
+++ b/frontend/src/types/file-item.ts
@@ -1,3 +1,5 @@
+import type { Stats } from './stats';
+
 type FileItemType = 'dir' | 'file';
 type FileItemStatus = 'untyped' | 'typing' | 'typed';
 
@@ -10,17 +12,12 @@ export type Typo = {
 export type TypingProgress = {
   row: number;
   column: number;
-  accuracy: number;
-  elapsedSeconds: number;
-  totalCorrectTypeCount: number;
-  totalTypoCount: number;
-  wpm: number;
   typos?: Typo[];
-};
+} & Stats;
 
 export type FileItem = {
   id: number;
-  fileItems: FileItem[] | [];
+  fileItems: FileItem[];
   name: string;
   path: string;
   status: FileItemStatus;

--- a/frontend/src/types/file-item.ts
+++ b/frontend/src/types/file-item.ts
@@ -10,8 +10,11 @@ export type Typo = {
 export type TypingProgress = {
   row: number;
   column: number;
-  time: number;
+  accuracy: number;
+  elapsedSeconds: number;
+  totalCorrectTypeCount: number;
   totalTypoCount: number;
+  wpm: number;
   typos?: Typo[];
 };
 

--- a/frontend/src/types/file-item.ts
+++ b/frontend/src/types/file-item.ts
@@ -11,7 +11,7 @@ export type TypingProgress = {
   row: number;
   column: number;
   time: number;
-  total_typo_count: number;
+  totalTypoCount: number;
   typos?: Typo[];
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
-export * from './extension';
-export * from './file-item';
-export * from './repository';
-export * from './repository-creation';
-export * from './stats';
-export * from './typing';
+export type { Extension } from './extension';
+export type { FileItem, TypingProgress, Typo } from './file-item';
+export type { Repository } from './repository';
+export type { RepositoryPreview, WizardData, WizardStep } from './repository-creation';
+export type { Stats } from './stats';
+export type { TypingStatus } from './typing';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,4 +2,5 @@ export * from './extension';
 export * from './file-item';
 export * from './repository';
 export * from './repository-creation';
+export * from './stats';
 export * from './typing';

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,7 +1,7 @@
 export type Stats = {
   accuracy: number;
-  totalCorrectTypeCount: number;
   elapsedSeconds: number;
+  totalCorrectTypeCount: number;
   totalTypoCount: number;
   wpm: number;
 };

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,0 +1,7 @@
+export type Stats = {
+  accuracy: number;
+  correctTypeCount: number;
+  elapsedSeconds: number;
+  typoCount: number;
+  wpm: number;
+};

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,7 +1,7 @@
 export type Stats = {
   accuracy: number;
-  correctTypeCount: number;
+  totalCorrectTypeCount: number;
   elapsedSeconds: number;
-  typoCount: number;
+  totalTypoCount: number;
   wpm: number;
 };


### PR DESCRIPTION
# issue
- #25 

# description
タイピング中の統計情報を表示するようにした。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - タイピングHUDで精度(%)・WPM・経過時間・ミスタイプ数・正打数を表示するコンパクトな統計パネルを追加
  - ライブ統計の開始/一時停止/再開/リセット/復元操作を実装しフロントから取得可能に

- **改善**
  - 進捗データの数値検証を強化し統計表示の信頼性を向上
  - API応答に統計（経過秒/正打数/ミスタイプ数）や計算済み精度・WPMを含めるよう拡張

- **テスト**
  - 統計の包括的な単体/統合テストを追加・既存テストを更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->