### PR TITLE
unprocessable_entityをunprocessable_contentに置き換えた

### DIFF
--- a/backend/app/controllers/api/auth_controller.rb
+++ b/backend/app/controllers/api/auth_controller.rb
@@ -9,7 +9,7 @@ module Api
       access_token = JsonWebToken.encode(user_id: user.id)
       render json: { access_token: access_token }, status: :ok
     rescue ActiveRecord::RecordInvalid => e
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { error: e.message }, status: :unprocessable_content
     rescue StandardError => e
       render json: { error: e.message }, status: :internal_server_error
     end

--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -25,13 +25,13 @@ module Api
         if @file_item.update_with_parent(file_item_params) && @repository.update(last_typed_at: Time.zone.now)
           render json: typed_file_items_response, status: :ok
         else
-          render json: @file_item.errors, status: :unprocessable_entity
+          render json: @file_item.errors, status: :unprocessable_content
         end
       when 'typing'
         if @file_item.update_with_typing_progress(file_item_params) && @repository.update(last_typed_at: Time.zone.now)
           render json: FileItemSerializer.new(@file_item, params: { children: true }), status: :ok
         else
-          render json: @file_item.errors, status: :unprocessable_entity
+          render json: @file_item.errors, status: :unprocessable_content
         end
       else
         render json: { error: 'Invalid status' }, status: :bad_request

--- a/backend/app/controllers/api/repositories_controller.rb
+++ b/backend/app/controllers/api/repositories_controller.rb
@@ -21,7 +21,7 @@ module Api
       repository_url = UrlUtils.extract_github_repository_path(url)
 
       if repository_url.nil?
-        render json: { error: 'Invalid URL' }, status: :unprocessable_entity
+        render json: { error: 'Invalid URL' }, status: :unprocessable_content
         return
       end
 
@@ -31,7 +31,7 @@ module Api
       if repository.save_with_file_items(client)
         render json: RepositorySerializer.new(repository), status: :created
       else
-        render json: repository.errors, status: :unprocessable_entity
+        render json: repository.errors, status: :unprocessable_content
       end
     rescue Octokit::NotFound
       render json: { error: 'Repository not found' }, status: :not_found
@@ -48,7 +48,7 @@ module Api
       repository_url = UrlUtils.extract_github_repository_path(url)
 
       if repository_url.nil?
-        render json: { error: 'Invalid URL' }, status: :unprocessable_entity
+        render json: { error: 'Invalid URL' }, status: :unprocessable_content
         return
       end
 

--- a/backend/spec/requests/api/auth_controller_spec.rb
+++ b/backend/spec/requests/api/auth_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Api::Auth', type: :request do
         invalid_params = { auth: { github_id: '12345' } }
         post '/api/auth/callback/github', params: invalid_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json).to have_key('error')
       end

--- a/backend/spec/requests/api/file_items_spec.rb
+++ b/backend/spec/requests/api/file_items_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe 'Api::FileItems', type: :request do
         patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
               params: { file_item: { status: :typed } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json['typing_progress.row']).to include("can't be blank")
         expect(json['typing_progress.column']).to include("can't be blank")
@@ -313,7 +313,7 @@ RSpec.describe 'Api::FileItems', type: :request do
         patch api_repository_file_item_path(repository_id: repository.id, id: untyped_file_item.id),
               params: { file_item: { status: :typing } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json['typing_progress.row']).to include("can't be blank")
         expect(json['typing_progress.column']).to include("can't be blank")

--- a/backend/spec/requests/api/repositories_spec.rb
+++ b/backend/spec/requests/api/repositories_spec.rb
@@ -208,21 +208,21 @@ RSpec.describe 'Api::Repositories', type: :request do
         allow(github_client_mock).to receive(:commits).with(valid_repository_url).and_return([commit])
       end
 
-      it 'returns unprocessable_entity status' do
+      it 'returns unprocessable_content status' do
         post api_repositories_path, params: { repository: { url: valid_url } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json['name']).to eq(['can\'t be blank'])
       end
     end
 
     context 'when url is invalid' do
-      it 'returns unprocessable_entity status' do
+      it 'returns unprocessable_content status' do
         invalid_url = 'https://invalid_url.com'
         post api_repositories_path, params: { repository: { url: invalid_url } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json['error']).to eq('Invalid URL')
       end
@@ -364,11 +364,11 @@ RSpec.describe 'Api::Repositories', type: :request do
     end
 
     context 'when url is invalid' do
-      it 'returns unprocessable_entity status' do
+      it 'returns unprocessable_content status' do
         invalid_url = 'https://invalid_url.com'
         get preview_api_repositories_path, params: { repository_preview: { url: invalid_url } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json['error']).to eq('Invalid URL')
       end


### PR DESCRIPTION
# issue
- #165 

# description
`Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.`との警告が出るため修正した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - APIのエラーレスポンス(HTTP 422)のステータス表現を「unprocessable_content」に統一。認証、ファイル項目更新、リポジトリ作成・プレビューで適用。ステータスコードやエラーメッセージは変更なし。

- テスト
  - 上記変更に合わせてリクエストスペックの期待値と記述を更新。挙動やペイロードの検証は従来どおり維持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->