### PR TITLE
英字以外を含むファイルはタイピング対象外とした

### DIFF
--- a/backend/app/controllers/api/file_items_controller.rb
+++ b/backend/app/controllers/api/file_items_controller.rb
@@ -68,9 +68,11 @@ module Api
       file_content = client.contents(@repository.url, path: @file_item.path, ref: @repository.commit_hash)[
         :content
       ]
-
       decoded_file_content = FileItem.decode_file_content(file_content)
-      @file_item.update(content: decoded_file_content)
+
+      update_params = { content: decoded_file_content }
+      update_params[:status] = :unsupported if FileItem.contains_non_ascii?(decoded_file_content)
+      @file_item.update(update_params)
     end
 
     def typed_file_items_response

--- a/backend/app/models/file_item.rb
+++ b/backend/app/models/file_item.rb
@@ -20,8 +20,16 @@ class FileItem < ApplicationRecord
   enum :status, {
     untyped: 0,
     typing: 1,
-    typed: 2
+    typed: 2,
+    unsupported: 3
   }
+
+  def self.contains_non_ascii?(file_content)
+    return false if file_content.blank?
+
+    # ASCII文字以外（英数字、記号、空白文字以外）が含まれているかチェック
+    file_content.match?(/[^\x00-\x7F]/)
+  end
 
   def self.decode_file_content(file_content)
     decoded_file_content = Base64.decode64(file_content).force_encoding('UTF-8')

--- a/backend/app/models/repository.rb
+++ b/backend/app/models/repository.rb
@@ -23,7 +23,7 @@ class Repository < ApplicationRecord
     if files.empty?
       1.0
     else
-      typed_count = files.where(status: :typed).count
+      typed_count = files.where(status: %i[typed unsupported]).count
       typed_count.to_f / files.count
     end
   end

--- a/backend/spec/models/file_item_spec.rb
+++ b/backend/spec/models/file_item_spec.rb
@@ -121,6 +121,27 @@ RSpec.describe FileItem, type: :model do
     end
   end
 
+  describe '.contains_non_ascii?' do
+    context 'when content is blank' do
+      it 'returns false' do
+        expect(described_class.contains_non_ascii?(nil)).to be false
+        expect(described_class.contains_non_ascii?('')).to be false
+      end
+    end
+
+    context 'when content contains only ASCII characters' do
+      it 'returns false' do
+        expect(described_class.contains_non_ascii?('Hello, World!')).to be false
+      end
+    end
+
+    context 'when content contains non-ASCII characters' do
+      it 'returns true' do
+        expect(described_class.contains_non_ascii?('こんにちは、世界！')).to be true
+      end
+    end
+  end
+
   describe '#full_path' do
     let(:root_dir) { create(:file_item, :directory, name: 'root_dir', repository:) }
     let(:middle_dir) { create(:file_item, :directory, name: 'middle_dir', repository:, parent: root_dir) }

--- a/backend/spec/models/repository_spec.rb
+++ b/backend/spec/models/repository_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Repository, type: :model do
     end
 
     context 'when only root level file_items' do
-      let!(:readme_file) { create(:file_item, repository: repository, parent: nil) }
-      let!(:license_file) { create(:file_item, repository: repository, parent: nil) }
-      let!(:src_directory) { create(:file_item, :directory, repository: repository, parent: nil) }
+      let!(:readme_file) { create(:file_item, repository:, parent: nil) }
+      let!(:license_file) { create(:file_item, repository:, parent: nil) }
+      let!(:src_directory) { create(:file_item, :directory, repository:, parent: nil) }
 
       it 'groups all file_items under nil key' do
         result = repository.file_items_grouped_by_parent
@@ -28,13 +28,13 @@ RSpec.describe Repository, type: :model do
     end
 
     context 'when nested file structure' do
-      let!(:root_dir) { create(:file_item, :directory, repository: repository, parent: nil) }
-      let!(:sub_dir) { create(:file_item, :directory, repository: repository, parent: root_dir) }
-      let!(:readme_file) { create(:file_item, repository: repository, parent: nil) }
-      let!(:main_file) { create(:file_item, repository: repository, parent: nil) }
-      let!(:controller_file) { create(:file_item, repository: repository, parent: root_dir) }
-      let!(:model_file) { create(:file_item, repository: repository, parent: root_dir) }
-      let!(:config_file) { create(:file_item, repository: repository, parent: sub_dir) }
+      let!(:root_dir) { create(:file_item, :directory, repository:, parent: nil) }
+      let!(:sub_dir) { create(:file_item, :directory, repository:, parent: root_dir) }
+      let!(:readme_file) { create(:file_item, repository:, parent: nil) }
+      let!(:main_file) { create(:file_item, repository:, parent: nil) }
+      let!(:controller_file) { create(:file_item, repository:, parent: root_dir) }
+      let!(:model_file) { create(:file_item, repository:, parent: root_dir) }
+      let!(:config_file) { create(:file_item, repository:, parent: sub_dir) }
 
       it 'groups file_items by their parent_id correctly' do
         result = repository.file_items_grouped_by_parent
@@ -47,10 +47,10 @@ RSpec.describe Repository, type: :model do
     end
 
     context 'when multiple children under same parent' do
-      let!(:parent_dir) { create(:file_item, :directory, repository: repository, parent: nil) }
-      let!(:service_file) { create(:file_item, repository: repository, parent: parent_dir) }
-      let!(:helper_file) { create(:file_item, repository: repository, parent: parent_dir) }
-      let!(:utils_directory) { create(:file_item, :directory, repository: repository, parent: parent_dir) }
+      let!(:parent_dir) { create(:file_item, :directory, repository:, parent: nil) }
+      let!(:service_file) { create(:file_item, repository:, parent: parent_dir) }
+      let!(:helper_file) { create(:file_item, repository:, parent: parent_dir) }
+      let!(:utils_directory) { create(:file_item, :directory, repository:, parent: parent_dir) }
 
       it 'groups multiple children under the same parent_id' do
         result = repository.file_items_grouped_by_parent
@@ -71,8 +71,8 @@ RSpec.describe Repository, type: :model do
 
     context 'when some files are typed (50%)' do
       it 'returns 0.5' do
-        create(:file_item, :typed, repository: repository)
-        create(:file_item, repository: repository, status: :untyped)
+        create(:file_item, :typed, repository:)
+        create(:file_item, repository:, status: :untyped)
 
         expect(repository.progress).to eq(0.5)
       end
@@ -80,10 +80,19 @@ RSpec.describe Repository, type: :model do
 
     context 'when all files are typed (100%)' do
       it 'returns 1.0' do
-        create(:file_item, :typed, repository: repository)
-        create(:file_item, :typed, repository: repository)
+        create(:file_item, :typed, repository:)
+        create(:file_item, :typed, repository:)
 
         expect(repository.progress).to eq(1.0)
+      end
+    end
+
+    context 'when some files are unsupported (50%)' do
+      it 'returns 0.5' do
+        create(:file_item, repository:, status: :unsupported)
+        create(:file_item, repository:, status: :untyped)
+
+        expect(repository.progress).to eq(0.5)
       end
     end
   end

--- a/frontend/__tests__/app/repositories/[id]/page.test.tsx
+++ b/frontend/__tests__/app/repositories/[id]/page.test.tsx
@@ -53,17 +53,25 @@ describe('RepositoryDetailPage', () => {
           path: 'dir1/nested-file2.ts',
           fileItems: [],
         },
+        {
+          id: 6,
+          name: 'japanese-file.ts',
+          type: 'file',
+          status: 'unsupported',
+          path: 'dir1/japanese-file.ts',
+          fileItems: [],
+        },
       ],
     },
     {
-      id: 6,
+      id: 7,
       name: 'dir2',
       type: 'dir',
       status: 'untyped',
       path: 'dir2',
       fileItems: [
         {
-          id: 7,
+          id: 8,
           name: 'nested-file3.ts',
           type: 'file',
           status: 'untyped',
@@ -73,7 +81,7 @@ describe('RepositoryDetailPage', () => {
       ],
     },
     {
-      id: 8,
+      id: 9,
       name: 'file3.ts',
       type: 'file',
       status: 'untyped',
@@ -103,6 +111,18 @@ describe('RepositoryDetailPage', () => {
     },
   };
 
+  const mockUnsupportedFileItem = {
+    data: {
+      id: 6,
+      name: 'japanese-file.ts',
+      type: 'file',
+      status: 'unsupported',
+      content: 'console.log("こんにちは、世界！");',
+      path: 'dir1/japanese-file.ts',
+      fileItems: [],
+    },
+  };
+
   const mockUpdatedFileItem = {
     ...mockFileItem.data,
     status: 'typing',
@@ -119,7 +139,9 @@ describe('RepositoryDetailPage', () => {
     mockUseSession();
     (useParams as jest.Mock).mockReturnValue({ id: '1' });
     jest.spyOn(axios, 'get').mockImplementation((url) => {
-      if (url.includes('/file_items/')) {
+      if (url.includes('/file_items/6')) {
+        return Promise.resolve(mockUnsupportedFileItem);
+      } else if (url.includes('/file_items/')) {
         return Promise.resolve(mockFileItem);
       }
       return Promise.resolve(mockRepository);
@@ -186,6 +208,13 @@ describe('RepositoryDetailPage', () => {
       expect(screen.getByText('dir1/nested-file1.ts')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'PLAY' })).toBeInTheDocument();
       expect(screen.getByText('console.log("Hello, world!");')).toBeInTheDocument();
+    });
+
+    it('renders unsupported file message when file status is unsupported', async () => {
+      await clickButton('dir1');
+      await clickButton('japanese-file.ts');
+
+      expect(screen.getByText('This file contains non-English characters, so it cannot be typed.')).toBeInTheDocument();
     });
 
     it('does not render highlight text', async () => {

--- a/frontend/__tests__/app/repositories/[id]/page.test.tsx
+++ b/frontend/__tests__/app/repositories/[id]/page.test.tsx
@@ -210,11 +210,12 @@ describe('RepositoryDetailPage', () => {
       expect(screen.getByText('console.log("Hello, world!");')).toBeInTheDocument();
     });
 
-    it('renders unsupported file message when file status is unsupported', async () => {
+    it('renders unsupported file message and does not render play button when file status is unsupported', async () => {
       await clickButton('dir1');
       await clickButton('japanese-file.ts');
 
       expect(screen.getByText('This file contains non-English characters, so it cannot be typed.')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'PLAY' })).not.toBeInTheDocument();
     });
 
     it('does not render highlight text', async () => {

--- a/frontend/__tests__/hooks/useTypingHandler.test.ts
+++ b/frontend/__tests__/hooks/useTypingHandler.test.ts
@@ -512,8 +512,8 @@ describe('useTypingHandler', () => {
           },
         ] as FileItem[];
 
-        const updateFunction = mockSetFileItems.mock.calls[0][0]; // (prev) => updateFileItemRecursively(prev, response.data)が格納される
-        const result = updateFunction(prevFileItems); // updateFileItemRecursively(prevFileItems, updatedFileItem)が呼ばれる
+        const updateFunction = mockSetFileItems.mock.calls[0][0]; // (prev) => updateFileItemInTree(prev, response.data)が格納される
+        const result = updateFunction(prevFileItems); // updateFileItemInTree(prevFileItems, updatedFileItem)が呼ばれる
 
         expect(result[0].status).toBe('typing');
         expect(result[1].fileItems?.[0].status).toBe('untyped');

--- a/frontend/src/components/repositories/FileTreeItem.tsx
+++ b/frontend/src/components/repositories/FileTreeItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, ChevronDown, ChevronRight, File, Folder } from 'lucide-react';
+import { AlertTriangle, Check, ChevronDown, ChevronRight, File, Folder } from 'lucide-react';
 import { useState } from 'react';
 
 import type { FileItem } from '@/types';
@@ -31,13 +31,15 @@ export default function FileTreeItem({ fileItem, level, selectedFileItem, onSele
   const isSelected = selectedFileItem?.id === fileItem.id;
   const isTyped = fileItem.status === 'typed';
   const isTyping = fileItem.status === 'typing';
-  const fileItems: FileItem[] = fileItem.fileItems;
+  const isUnsupported = fileItem.status === 'unsupported';
+  const fileItems: FileItem[] = fileItem.fileItems || [];
   const sortedFileItems = sortFileItems(fileItems);
   const isDir = fileItem.type === 'dir';
 
   const fileNameColorClass = () => {
     if (isSelected) return 'text-primary font-bold';
     if (isTyped) return 'text-secondary';
+    if (isUnsupported) return 'text-muted-foreground';
     return '';
   };
 
@@ -77,6 +79,8 @@ export default function FileTreeItem({ fileItem, level, selectedFileItem, onSele
               <div className="mr-2 ml-auto flex h-4 w-4 flex-shrink-0 items-center justify-center">
                 <div className="bg-muted-foreground h-2 w-2 rounded-full shadow-lg" />
               </div>
+            ) : isUnsupported ? (
+              <AlertTriangle size={16} className="text-muted-foreground mr-2 ml-auto flex-shrink-0" />
             ) : null}
           </>
         )}

--- a/frontend/src/components/repositories/FileTreeItem.tsx
+++ b/frontend/src/components/repositories/FileTreeItem.tsx
@@ -36,7 +36,7 @@ export default function FileTreeItem({ fileItem, level, selectedFileItem, onSele
   const sortedFileItems = sortFileItems(fileItems);
   const isDir = fileItem.type === 'dir';
 
-  const fileNameColorClass = () => {
+  const getFileNameClass = () => {
     if (isSelected) return 'text-primary font-bold';
     if (isTyped) return 'text-secondary';
     if (isUnsupported) return 'text-muted-foreground';
@@ -57,22 +57,29 @@ export default function FileTreeItem({ fileItem, level, selectedFileItem, onSele
             <span className="mr-1 flex-shrink-0">
               {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
             </span>
-            <Folder size={16} className="mr-1 flex-shrink-0" />
-            <span className={fileNameColorClass()}>{fileItem.name}</span>
+            <div
+              className={`
+                flex items-center
+                ${getFileNameClass()}
+              `}
+            >
+              <Folder size={16} className="mr-1 flex-shrink-0" />
+              <span>{fileItem.name}</span>
+            </div>
             {isTyped && <Check size={16} className="text-secondary mr-2 ml-auto flex-shrink-0" />}
           </>
         ) : (
           <>
             <div className="mr-1 w-4 flex-shrink-0"></div>
-            <File size={16} className="mr-1 flex-shrink-0" />
-            <span
+            <div
               className={`
-                truncate
-                ${fileNameColorClass()}
+                flex items-center
+                ${getFileNameClass()}
               `}
             >
-              {fileItem.name}
-            </span>
+              <File size={16} className="mr-1 flex-shrink-0" />
+              <span className="truncate">{fileItem.name}</span>
+            </div>
             {isTyped ? (
               <Check size={16} className="text-secondary mr-2 ml-auto flex-shrink-0" />
             ) : isTyping ? (

--- a/frontend/src/components/repositories/FileTreeItem.tsx
+++ b/frontend/src/components/repositories/FileTreeItem.tsx
@@ -64,7 +64,7 @@ export default function FileTreeItem({ fileItem, level, selectedFileItem, onSele
               `}
             >
               <Folder size={16} className="mr-1 flex-shrink-0" />
-              <span>{fileItem.name}</span>
+              <span className="truncate">{fileItem.name}</span>
             </div>
             {isTyped && <Check size={16} className="text-secondary mr-2 ml-auto flex-shrink-0" />}
           </>

--- a/frontend/src/components/repositories/RepositoryDetail.tsx
+++ b/frontend/src/components/repositories/RepositoryDetail.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 
 import { useTypingHandler } from '@/hooks/useTypingHandler';
 import type { FileItem, TypingStatus } from '@/types';
+import { updateFileItemInTree } from '@/utils/file-item';
 import { Card } from '../ui/card';
 import Loading from '../ui/loading';
 import CongratulationModal from './CongratulationModal';
@@ -32,21 +33,6 @@ export default function RepositoryDetail({ initialFileItems }: RepositoryDetailP
     setFileItems,
     setTypingStatus,
   });
-
-  const updateFileItemInTree = (fileItems: FileItem[], updatedFileItem: FileItem): FileItem[] => {
-    return fileItems.map((fileItem) => {
-      if (fileItem.id === updatedFileItem.id) {
-        return updatedFileItem;
-      }
-      if (fileItem.fileItems && fileItem.fileItems.length > 0) {
-        return {
-          ...fileItem,
-          fileItems: updateFileItemInTree(fileItem.fileItems, updatedFileItem),
-        };
-      }
-      return fileItem;
-    });
-  };
 
   const handleFileSelect = async (selectedFileItem: FileItem) => {
     if (typingStatus === 'typing') {

--- a/frontend/src/components/repositories/TypingContent.tsx
+++ b/frontend/src/components/repositories/TypingContent.tsx
@@ -46,6 +46,10 @@ export default function TypingContent({
         </div>
       ) : typingStatus === 'completed' ? (
         <TypingResult stats={stats} targetTextLines={targetTextLines} typedTextLines={typedTextLines} />
+      ) : typingStatus === 'unsupported' ? (
+        <div className="h-full overflow-auto px-4">
+          <div className="p-6 text-center">This file contains non-English characters, so it cannot be typed.</div>
+        </div>
       ) : null}
     </>
   );

--- a/frontend/src/components/repositories/TypingHeader.tsx
+++ b/frontend/src/components/repositories/TypingHeader.tsx
@@ -62,19 +62,21 @@ export default function TypingHeader({
   return (
     <div className="flex items-center justify-between border-b px-4 pb-2">
       <div className="truncate">{fileItemName}</div>
-      <div className="flex gap-2">
-        <Button variant="outline" size="sm" onClick={handleToggleTyping} aria-label={buttonLabel}>
-          {buttonIcon}
-          <span className="ml-1">{buttonLabel}</span>
-        </Button>
-
-        {(typingStatus === 'typing' || typingStatus === 'paused') && (
-          <Button variant="outline" size="sm" onClick={resetTyping} aria-label="RESET">
-            <RotateCcw size={16} />
-            <span className="ml-1">RESET</span>
+      {typingStatus !== 'unsupported' && (
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={handleToggleTyping} aria-label={buttonLabel}>
+            {buttonIcon}
+            <span className="ml-1">{buttonLabel}</span>
           </Button>
-        )}
-      </div>
+
+          {(typingStatus === 'typing' || typingStatus === 'paused') && (
+            <Button variant="outline" size="sm" onClick={resetTyping} aria-label="RESET">
+              <RotateCcw size={16} />
+              <span className="ml-1">RESET</span>
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useTypingHandler.ts
+++ b/frontend/src/hooks/useTypingHandler.ts
@@ -41,7 +41,7 @@ export function useTypingHandler({
   const params = useParams();
   const typingStats = useTypingStats();
 
-  const setupTypingState = async (fileItemId: number) => {
+  const setupTypingState = async (fileItemId: number): Promise<FileItem | null> => {
     setErrorMessage(null);
 
     try {
@@ -59,7 +59,7 @@ export function useTypingHandler({
         setTypedTextLines(initialTypedTextLines);
         setCursorRow(0);
         typingStats.resetStats();
-        return;
+        return fetchedFileItem;
       }
 
       const { row: currentRow, column: currentColumn, typos = [] } = fetchedFileItem.typingProgress;
@@ -86,12 +86,15 @@ export function useTypingHandler({
 
       const { accuracy, elapsedSeconds, totalCorrectTypeCount, totalTypoCount, wpm } = fetchedFileItem.typingProgress;
       typingStats.restoreStats(accuracy, elapsedSeconds, totalCorrectTypeCount, totalTypoCount, wpm);
+
+      return fetchedFileItem;
     } catch (error) {
       if (axios.isAxiosError(error)) {
         setErrorMessage(error.message);
       } else {
         setErrorMessage('An error occurred. Please try again.');
       }
+      return null;
     }
   };
 

--- a/frontend/src/hooks/useTypingHandler.ts
+++ b/frontend/src/hooks/useTypingHandler.ts
@@ -6,6 +6,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'reac
 import { FileItem, Repository, Stats, TypingStatus, Typo } from '@/types';
 import { axiosPatch } from '@/utils/axios';
 import { fetcher } from '@/utils/fetcher';
+import { updateFileItemInTree } from '@/utils/file-item';
 import { sortFileItems } from '@/utils/sort';
 import { useTypingStats } from './useTypingStats';
 
@@ -124,7 +125,7 @@ export function useTypingHandler({
       };
 
       const response = await axiosPatch(url, accessToken, postData);
-      setFileItems((prev) => updateFileItemRecursively(prev, response.data));
+      setFileItems((prev) => updateFileItemInTree(prev, response.data));
       setTypingStatus('paused');
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -381,14 +382,4 @@ function restoreTypedTextLine(row: number, targetTextLine: string, typos: Typo[]
   const typoMap = new Map(typos.filter((typo) => typo.row === row).map((typo) => [typo.column, typo.character]));
 
   return [...targetTextLine].map((char, index) => typoMap.get(index) ?? char).join('');
-}
-
-function updateFileItemRecursively(fileItems: FileItem[], updatedFileItem: FileItem): FileItem[] {
-  return fileItems.map((fileItem) => {
-    if (fileItem.id === updatedFileItem.id) return updatedFileItem;
-
-    return fileItem.fileItems?.length
-      ? { ...fileItem, fileItems: updateFileItemRecursively(fileItem.fileItems, updatedFileItem) }
-      : fileItem;
-  });
 }

--- a/frontend/src/types/file-item.ts
+++ b/frontend/src/types/file-item.ts
@@ -1,7 +1,7 @@
 import type { Stats } from './stats';
 
 type FileItemType = 'dir' | 'file';
-type FileItemStatus = 'untyped' | 'typing' | 'typed';
+type FileItemStatus = 'untyped' | 'typing' | 'typed' | 'unsupported';
 
 export type Typo = {
   row: number;

--- a/frontend/src/types/typing.ts
+++ b/frontend/src/types/typing.ts
@@ -1,1 +1,1 @@
-export type TypingStatus = 'ready' | 'typing' | 'paused' | 'completed';
+export type TypingStatus = 'ready' | 'typing' | 'paused' | 'completed' | 'unsupported';

--- a/frontend/src/utils/file-item.ts
+++ b/frontend/src/utils/file-item.ts
@@ -1,0 +1,11 @@
+import { FileItem } from '@/types/file-item';
+
+export function updateFileItemInTree(fileItems: FileItem[], updatedFileItem: FileItem): FileItem[] {
+  return fileItems.map((fileItem) => {
+    if (fileItem.id === updatedFileItem.id) return updatedFileItem;
+
+    return fileItem.fileItems?.length
+      ? { ...fileItem, fileItems: updateFileItemInTree(fileItem.fileItems, updatedFileItem) }
+      : fileItem;
+  });
+}


### PR DESCRIPTION
# issue
- #98 

# description
- 英字（アスキー文字）以外を含むファイルはタイピングできないようにした
- リポジトリの達成度の計算時にはタイプ済み扱いとした
- ファイル内容の初回取得時にタイピング対象外かの判定は行われるため、一度ファイルを選択しないと達成度に含まれない



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 非英語（非ASCII）文字を含むファイルを「未対応」と判定して表示
  - ファイル選択時に「このファイルは非英語文字を含むためタイピングできません」と明示表示
  - 未対応ファイルではPLAYなどの操作ボタンを非表示にし、ツリーに未対応アイコン/スタイルを追加
  - 進捗計算に未対応ファイルを含めて完了率へ反映

- **テスト**
  - 未対応判定、API取得時の状態更新、およびフロントの未対応表示・操作制限のテスト追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->