### PR TITLE
エラー時にヘッダーが表示されない不具合を修正した

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,13 +3,11 @@ import { Github } from 'lucide-react';
 import Image from 'next/image';
 
 import { SignIn } from '@/components/common/AuthButton';
-import Header from '@/components/common/Header';
+import PageLayout from '@/components/common/PageLayout';
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-
+    <PageLayout>
       <section className="bg-background relative flex-1 overflow-hidden">
         <div
           className={`
@@ -162,6 +160,6 @@ export default function Home() {
           </div>
         </div>
       </section>
-    </div>
+    </PageLayout>
   );
 }

--- a/frontend/src/app/repositories/[id]/page.tsx
+++ b/frontend/src/app/repositories/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from '@/auth';
-import Header from '@/components/common/Header';
+import PageLayout from '@/components/common/PageLayout';
 import DeleteRepositoryDialog from '@/components/repositories/DeleteRepositoryDialog';
 import RepositoryDetail from '@/components/repositories/RepositoryDetail';
 import { FileItem, Repository } from '@/types';
@@ -22,7 +22,11 @@ export default async function RepositoryDetailPage({ params }: RepositoryDetailP
     repository = await fetcher(url, accessToken);
   } catch (error) {
     const errorMessage = extractErrorMessage(error);
-    return <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>;
+    return (
+      <PageLayout title="Repository">
+        <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>
+      </PageLayout>
+    );
   }
 
   const fileItems: FileItem[] | [] = repository.fileItems;
@@ -30,11 +34,10 @@ export default async function RepositoryDetailPage({ params }: RepositoryDetailP
   const moreComponent = <DeleteRepositoryDialog repository={repository} />;
 
   return (
-    <div className="flex h-screen flex-col">
-      <Header title={repository.name} moreComponent={moreComponent} />
+    <PageLayout title={repository.name} moreComponent={moreComponent} className="flex h-screen flex-col">
       <div className="flex-1 overflow-hidden">
         <RepositoryDetail initialFileItems={sortedFileItems} />
       </div>
-    </div>
+    </PageLayout>
   );
 }

--- a/frontend/src/app/repositories/new/page.tsx
+++ b/frontend/src/app/repositories/new/page.tsx
@@ -1,17 +1,16 @@
 import { NextPage } from 'next';
 
-import Header from '@/components/common/Header';
+import PageLayout from '@/components/common/PageLayout';
 import RepositoryCreationWizard from '@/components/repositories/new/RepositoryCreationWizard';
 
 const NewRepositoryPage: NextPage = () => {
   return (
-    <>
-      <Header title="New Repository" />
+    <PageLayout title="New Repository">
       <div className="p-4">
         <p className="mb-6 text-center">Import a GitHub repository to start typing practice.</p>
         <RepositoryCreationWizard />
       </div>
-    </>
+    </PageLayout>
   );
 };
 

--- a/frontend/src/app/repositories/page.tsx
+++ b/frontend/src/app/repositories/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/auth';
 
-import Header from '@/components/common/Header';
+import PageLayout from '@/components/common/PageLayout';
 import RepositoryFooter from '@/components/repositories/index/RepositoryFooter';
 import RepositoryList from '@/components/repositories/index/RepositoryList';
 import { PAGINATION } from '@/constants/pagination';
@@ -38,20 +38,23 @@ export default async function RepositoriesPage({ searchParams }: Props) {
     repositoriesResponse = await repositoriesFetcher(url, accessToken);
   } catch (error) {
     const errorMessage = extractErrorMessage(error);
-    return <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>;
+    return (
+      <PageLayout title="Repositories">
+        <div className="flex h-screen items-center justify-center p-8">{errorMessage}</div>
+      </PageLayout>
+    );
   }
 
   const sortedRepositories = sortRepositories(repositoriesResponse.repositories);
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header title="Repositories" />
+    <PageLayout title="Repositories">
       <div className="flex-1">
         <div className="flex min-h-full flex-col px-2">
           <RepositoryList repositories={sortedRepositories} pagination={repositoriesResponse.pagination} />
         </div>
       </div>
       <RepositoryFooter />
-    </div>
+    </PageLayout>
   );
 }

--- a/frontend/src/components/common/PageLayout.tsx
+++ b/frontend/src/components/common/PageLayout.tsx
@@ -1,0 +1,22 @@
+import Header from '@/components/common/Header';
+
+type PageLayoutProps = {
+  children: React.ReactNode;
+  title?: string;
+  moreComponent?: React.ReactNode;
+  className?: string;
+};
+
+export default function PageLayout({
+  title = '',
+  children,
+  moreComponent,
+  className = 'flex min-h-screen flex-col',
+}: PageLayoutProps) {
+  return (
+    <div className={className}>
+      <Header title={title} moreComponent={moreComponent} />
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
# issue
- #200 

# description
ヘッダーにページごとに異なるタイトルやボタンを表示するために、各`page.tsx`でヘッダーコンポーネントをレンダーしている。
`page.tsx`でエラーが起きた際にエラーメッセージしかレンダーしていなかったため、エラー時もヘッダーをレンダーするように修正した。